### PR TITLE
fix(GODT-2242): Don't send any 2fa information if not needed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Editor files
+.*.sw?
+*~
+.idea
+.vscode

--- a/manager_auth.go
+++ b/manager_auth.go
@@ -44,7 +44,7 @@ func (m *Manager) NewClientWithLogin(ctx context.Context, username string, passw
 		return nil, Auth{}, err
 	}
 
-	auth, err := m.auth(ctx, AuthReqNo2FA{
+	auth, err := m.auth(ctx, AuthReq{
 		Username:        username,
 		ClientProof:     base64.StdEncoding.EncodeToString(proofs.ClientProof),
 		ClientEphemeral: base64.StdEncoding.EncodeToString(proofs.ClientEphemeral),
@@ -90,7 +90,7 @@ func (m *Manager) AuthModulus(ctx context.Context) (AuthModulus, error) {
 	return res, nil
 }
 
-func (m *Manager) auth(ctx context.Context, req AuthReqNo2FA) (Auth, error) {
+func (m *Manager) auth(ctx context.Context, req AuthReq) (Auth, error) {
 	var res struct {
 		Auth
 	}

--- a/manager_auth_types.go
+++ b/manager_auth_types.go
@@ -34,15 +34,8 @@ type FIDO2Req struct {
 }
 
 type AuthReq struct {
-	Auth2FAReq
+	Auth2FAReq `json:",omitempty"`
 
-	Username        string
-	ClientEphemeral string
-	ClientProof     string
-	SRPSession      string
-}
-
-type AuthReqNo2FA struct {
 	Username        string
 	ClientEphemeral string
 	ClientProof     string
@@ -93,8 +86,8 @@ const (
 )
 
 type Auth2FAReq struct {
-	TwoFactorCode string
-	FIDO2         FIDO2Req
+	TwoFactorCode string   `json:",omitempty"`
+	FIDO2         FIDO2Req `json:",omitempty"`
 }
 
 type AuthRefreshReq struct {


### PR DESCRIPTION
In POST `/auth/v4/2fa` you should be including the FIDO2 object only if it's filled, if not we'll attempt validating it

Docs specify
> TwoFactorCode either this or the FIDO2 object