### PR TITLE
fix(GODT-2246): added missing API error code.

### DIFF
--- a/response.go
+++ b/response.go
@@ -20,6 +20,7 @@ const (
 	InvalidValue              Code = 2001
 	AppVersionMissingCode     Code = 5001
 	AppVersionBadCode         Code = 5003
+	UsernameInvalid           Code = 6003 // Deprecated, but still used.
 	PasswordWrong             Code = 8002
 	HumanVerificationRequired Code = 9001
 	PaidPlanRequired          Code = 10004


### PR DESCRIPTION
Error code 6003 is marked as deprecated but still returned by login for non valid emails.