### PR TITLE
feat: Implement NetError (and rename proton.Error to proton.APIError)

### DIFF
--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *Client) doRes(ctx context.Context, fn func(*resty.Request) (*resty.Resp
 	if res != nil {
 		// If we receive no response, we can't do anything.
 		if res.RawResponse == nil {
-			return nil, fmt.Errorf("received no response from API: %w", err)
+			return nil, newNetError(err, "received no response from API")
 		}
 
 		// If we receive a 401, we need to refresh the auth.

--- a/contact_types.go
+++ b/contact_types.go
@@ -153,7 +153,7 @@ type CreateContactsRes struct {
 	Index int
 
 	Response struct {
-		Error
+		APIError
 		Contact Contact
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -65,7 +65,7 @@ func (m *Manager) handleError(req *resty.Request, err error) {
 		return
 	}
 
-	apiErr, ok := resErr.Response.Error().(*Error)
+	apiErr, ok := resErr.Response.Error().(*APIError)
 	if !ok {
 		return
 	}

--- a/manager_builder.go
+++ b/manager_builder.go
@@ -92,7 +92,7 @@ func (builder *managerBuilder) build() *Manager {
 	m.rc.SetRetryAfter(catchRetryAfter)
 
 	// Set the data type of API errors.
-	m.rc.SetError(&Error{})
+	m.rc.SetError(&APIError{})
 
 	return m
 }

--- a/message_import.go
+++ b/message_import.go
@@ -29,7 +29,7 @@ func (c *Client) ImportMessages(ctx context.Context, addrKR *crypto.KeyRing, wor
 
 			for _, res := range res {
 				if res.Code != SuccessCode {
-					return nil, fmt.Errorf("failed to import message: %w", res.Error)
+					return nil, fmt.Errorf("failed to import message: %w", res.APIError)
 				}
 			}
 

--- a/message_import_types.go
+++ b/message_import_types.go
@@ -28,7 +28,7 @@ type ImportMetadata struct {
 }
 
 type ImportRes struct {
-	Error
+	APIError
 	MessageID string
 }
 

--- a/message_types.go
+++ b/message_types.go
@@ -188,5 +188,5 @@ func (res LabelMessagesRes) ok() bool {
 
 type LabelMessageRes struct {
 	ID       string
-	Response Error
+	Response APIError
 }

--- a/server/messages.go
+++ b/server/messages.go
@@ -278,14 +278,14 @@ func (s *Server) handlePutMailMessagesImport() gin.HandlerFunc {
 			)
 			if err != nil {
 				res.Response = proton.ImportRes{
-					Error: proton.Error{
+					APIError: proton.APIError{
 						Code:    proton.InvalidValue,
 						Message: fmt.Sprintf("failed to import: %v", err),
 					},
 				}
 			} else {
 				res.Response = proton.ImportRes{
-					Error:     proton.Error{Code: proton.SuccessCode},
+					APIError:  proton.APIError{Code: proton.SuccessCode},
 					MessageID: messageID,
 				}
 			}

--- a/server/router.go
+++ b/server/router.go
@@ -140,12 +140,12 @@ func (s *Server) requireValidAppVersion() gin.HandlerFunc {
 		appVersion := c.Request.Header.Get("x-pm-appversion")
 
 		if appVersion == "" {
-			c.AbortWithStatusJSON(http.StatusBadRequest, proton.Error{
+			c.AbortWithStatusJSON(http.StatusBadRequest, proton.APIError{
 				Code:    proton.AppVersionMissingCode,
 				Message: "Missing x-pm-appversion header",
 			})
 		} else if ok := s.validateAppVersion(appVersion); !ok {
-			c.AbortWithStatusJSON(http.StatusBadRequest, proton.Error{
+			c.AbortWithStatusJSON(http.StatusBadRequest, proton.APIError{
 				Code:    proton.AppVersionBadCode,
 				Message: "This version of the app is no longer supported, please update to continue using the app",
 			})


### PR DESCRIPTION
NetError is an error type returned when no response was received from the API. This allows callers to determine whether their call failed due to a network level error.

Additionally, proton.APIError now has Status to see what the status code was in the response that triggered the error.