### PR TITLE
feat(GODT-1556): simulate reply behaviour on fakeAPI side.

### DIFF
--- a/server/backend/api.go
+++ b/server/backend/api.go
@@ -508,14 +508,15 @@ func (b *Backend) CreateDraft(userID, addrID string, draft proton.DraftTemplate,
 	return withAcc(b, userID, func(acc *account) (proton.Message, error) {
 		return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
 			return withLabels(b, func(labels map[string]*label) (proton.Message, error) {
-				// Convert the parentID into externalRef.
-				if parentID != ""  {
+				// Convert the parentID into externalRef.\
+				var parentRef string
+				if parentID != "" {
 					parentMsg, ok := messages[parentID]
 					if ok {
-						parentID = "<"+ parentMsg.externalID + ">"
+						parentRef = "<" + parentMsg.externalID + ">"
 					}
 				}
-				msg := newMessageFromTemplate(addrID, draft, parentID)
+				msg := newMessageFromTemplate(addrID, draft, parentRef)
 
 				// Drafts automatically get the sysLabel "Drafts".
 				msg.addLabel(proton.DraftsLabel, labels)

--- a/server/backend/message.go
+++ b/server/backend/message.go
@@ -19,7 +19,6 @@ type message struct {
 	labelIDs   []string
 	sysLabel   *string
 	attIDs     []string
-	references []string
 	inReplyTo  string
 
 	subject  string
@@ -78,27 +77,23 @@ func newMessageFromSent(addrID, armBody string, msg *message) *message {
 		sender:   msg.sender,
 		toList:   msg.toList,
 		ccList:   msg.ccList,
-		bccList:  nil,  // BCC is not sent to the recipient
+		bccList:  nil, // BCC is not sent to the recipient
 		replytos: msg.replytos,
 		date:     time.Now(),
 
-		armBody:  armBody,
-		mimeType: msg.mimeType,
-		references: msg.references,
+		armBody:   armBody,
+		mimeType:  msg.mimeType,
 		inReplyTo: msg.inReplyTo,
 	}
 }
 
-func newMessageFromTemplate(addrID string, template proton.DraftTemplate, parentID string) *message {
-	var ref []string
-	ref = append(ref, parentID)
+func newMessageFromTemplate(addrID string, template proton.DraftTemplate, parentRef string) *message {
 	return &message{
 		messageID:  uuid.NewString(),
 		externalID: template.ExternalID,
 		addrID:     addrID,
 		sysLabel:   pointer(""),
-		references: ref,
-		inReplyTo:  parentID,
+		inReplyTo:  parentRef,
 
 		subject: template.Subject,
 		sender:  template.Sender,
@@ -207,8 +202,8 @@ func (msg *message) getHeader() string {
 		builder.WriteString("Content-Type: " + string(msg.mimeType) + "\r\n")
 	}
 
-	if len(msg.references) > 0 {
-		builder.WriteString("References: " + strings.Join(msg.references, ", ") + "\r\n")
+	if len(msg.inReplyTo) > 0 {
+		builder.WriteString("References: " + msg.inReplyTo + "\r\n")
 	}
 
 	if msg.inReplyTo != "" {

--- a/server/messages.go
+++ b/server/messages.go
@@ -101,7 +101,7 @@ func (s *Server) postMailMessages(c *gin.Context) {
 		return
 	}
 
-	message, err := s.b.CreateDraft(c.GetString("UserID"), addrID, req.Message)
+	message, err := s.b.CreateDraft(c.GetString("UserID"), addrID, req.Message, req.ParentID)
 	if err != nil {
 		c.AbortWithStatus(http.StatusUnprocessableEntity)
 		return


### PR DESCRIPTION
When creating the draft we need to convert the parentID into valid reference to be stored as references/in-reply-to.
Then on message creation on the fake server we need to populate the in-reply-to/references fields.