### PR TITLE
fix(GODT-2574): Use sequential operations for label/unlabel

### DIFF
--- a/message_types.go
+++ b/message_types.go
@@ -204,14 +204,14 @@ type LabelMessagesRes struct {
 	UndoToken UndoToken
 }
 
-func (res LabelMessagesRes) ok() bool {
+func (res LabelMessagesRes) ok() (bool, string) {
 	for _, resp := range res.Responses {
 		if resp.Response.Code != SuccessCode {
-			return false
+			return false, resp.Response.Error()
 		}
 	}
 
-	return true
+	return true, ""
 }
 
 type LabelMessageRes struct {


### PR DESCRIPTION
Do not call label/unlabel operations in parallel when we have more than 150 messages. This can cause the operation to fail in the backend.

This patch also improves the error message by returning the first error message for the failed operation.