### PR TITLE
fix(GODT-2626): Do not merge events

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -105,11 +105,14 @@ func TestMaxEventMerge(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	event, more, err := c.GetEvent(ctx, latestID)
+	events, more, err := c.GetEvent(ctx, latestID)
 	require.NoError(t, err)
 	require.True(t, more)
+	require.Equal(t, 50, len(events))
 
-	event, more, err = c.GetEvent(ctx, event.EventID)
+	events2, more, err := c.GetEvent(ctx, events[len(events)-1].EventID)
+	require.NotEqual(t, events, events2)
 	require.NoError(t, err)
 	require.False(t, more)
+	require.Equal(t, 26, len(events2))
 }

--- a/event_types.go
+++ b/event_types.go
@@ -70,31 +70,6 @@ func (event Event) String() string {
 	return fmt.Sprintf("Event %s: %s", event.EventID, strings.Join(parts, ", "))
 }
 
-// merge combines this event with the other event (assumed to be newer!).
-// TODO: Intelligent merging: if there are multiple EventUpdate(Flags) events, can we just take the latest one?
-func (event *Event) merge(other Event) error {
-	event.EventID = other.EventID
-
-	if other.User != nil {
-		event.User = other.User
-	}
-
-	if other.MailSettings != nil {
-		event.MailSettings = other.MailSettings
-	}
-
-	// For now, label events are simply appended.
-	event.Labels = append(event.Labels, other.Labels...)
-
-	// For now, message events are simply appended.
-	event.Messages = append(event.Messages, other.Messages...)
-
-	// For now, address events are simply appended.
-	event.Addresses = append(event.Addresses, other.Addresses...)
-
-	return nil
-}
-
 type RefreshFlag uint8
 
 const (

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -296,12 +296,13 @@ func TestServer_MessagesDeleteAfterUpdate(t *testing.T) {
 				event, more, err := c.GetEvent(ctx, eventID)
 				require.NoError(t, err)
 				require.False(t, more)
+				require.Equal(t, 1, len(event))
 
 				// The event should have the correct number of message events.
-				require.Len(t, event.Messages, 500)
+				require.Len(t, event[0].Messages, 500)
 
 				// All the events should be delete events.
-				for _, message := range event.Messages {
+				for _, message := range event[0].Messages {
 					require.Equal(t, proton.EventDelete, message.Action)
 				}
 			})
@@ -402,18 +403,18 @@ func TestServer_Events_Multi(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, latest, latestAgain)
 
-				event, more, err := c.GetEvent(ctx, latest)
+				events, more, err := c.GetEvent(ctx, latest)
 				require.NoError(t, err)
 				require.False(t, more)
 
 				// The event should be empty.
-				require.Equal(t, proton.Event{EventID: event.EventID}, event)
+				require.Equal(t, []proton.Event{{EventID: events[0].EventID}}, events)
 
 				// After fetching an empty event, its ID should still be the latest.
-				eventAgain, more, err := c.GetEvent(ctx, event.EventID)
+				eventAgain, more, err := c.GetEvent(ctx, events[0].EventID)
 				require.NoError(t, err)
 				require.False(t, more)
-				require.Equal(t, eventAgain.EventID, event.EventID)
+				require.Equal(t, eventAgain[0].EventID, events[0].EventID)
 			})
 		}
 	})


### PR DESCRIPTION
API has advised that doing this can lead to invalid state. We now return an array of events so that those are processed in order.