### PR TITLE
test(GODT-2578): Message Dedup for Server

### DIFF
--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -9,3 +9,7 @@ import (
 func newMessageLiteral(from, to string) []byte {
 	return []byte(fmt.Sprintf("From: %v\r\nReceiver: %v\r\nSubject: %v\r\n\r\nHello World!", from, to, uuid.New()))
 }
+
+func newMessageLiteralWithSubject(from, to, subject string) []byte {
+	return []byte(fmt.Sprintf("From: %v\r\nReceiver: %v\r\nSubject: %v\r\n\r\nHello World!", from, to, subject))
+}

--- a/server/server_builder.go
+++ b/server/server_builder.go
@@ -23,6 +23,7 @@ type serverBuilder struct {
 	proxyTransport *http.Transport
 	cacher         AuthCacher
 	rateLimiter    *rateLimiter
+	enableDedup    bool
 }
 
 func newServerBuilder() *serverBuilder {
@@ -49,7 +50,7 @@ func (builder *serverBuilder) build() *Server {
 
 	s := &Server{
 		r: gin.New(),
-		b: backend.New(time.Hour, builder.domain),
+		b: backend.New(time.Hour, builder.domain, builder.enableDedup),
 
 		domain:         builder.domain,
 		proxyOrigin:    builder.origin,
@@ -252,4 +253,14 @@ func WithListener(listener net.Listener) Option {
 	return withNetListener{
 		listener: listener,
 	}
+}
+
+type withMessageDedup struct{}
+
+func (withMessageDedup) config(builder *serverBuilder) {
+	builder.enableDedup = true
+}
+
+func WithMessageDedup() Option {
+	return &withMessageDedup{}
 }


### PR DESCRIPTION
Implement basic message deduplication for GPA server. This functionality is opt-in. It's not enabled by default in order to not break any existing tests are written against the previous behavior.