### PR TITLE
fix(2822): Refactor GetMessageIDs

### DIFF
--- a/message.go
+++ b/message.go
@@ -67,11 +67,11 @@ func (c *Client) GetMessageMetadata(ctx context.Context, filter MessageFilter) (
 	})
 }
 
-func (c *Client) GetMessageIDs(ctx context.Context, afterID string) ([]string, error) {
+func (c *Client) GetAllMessageIDs(ctx context.Context, afterID string) ([]string, error) {
 	var messageIDs []string
 
 	for ; ; afterID = messageIDs[len(messageIDs)-1] {
-		page, err := c.getMessageIDs(ctx, afterID)
+		page, err := c.GetMessageIDs(ctx, afterID, maxMessageIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,11 @@ func (c *Client) UnlabelMessages(ctx context.Context, messageIDs []string, label
 	return nil
 }
 
-func (c *Client) getMessageIDs(ctx context.Context, afterID string) ([]string, error) {
+func (c *Client) GetMessageIDs(ctx context.Context, afterID string, limit int) ([]string, error) {
+	if limit > maxMessageIDs {
+		limit = maxMessageIDs
+	}
+
 	var res struct {
 		IDs []string
 	}
@@ -199,7 +203,7 @@ func (c *Client) getMessageIDs(ctx context.Context, afterID string) ([]string, e
 			r = r.SetQueryParam("AfterID", afterID)
 		}
 
-		return r.SetQueryParam("Limit", strconv.Itoa(maxMessageIDs)).SetResult(&res).Get("/mail/v4/messages/ids")
+		return r.SetQueryParam("Limit", strconv.Itoa(limit)).SetResult(&res).Get("/mail/v4/messages/ids")
 	}); err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -237,11 +237,11 @@ func TestServer_MessageIDs(t *testing.T) {
 	withServer(t, func(ctx context.Context, s *Server, m *proton.Manager) {
 		withUser(ctx, t, s, m, "user", "pass", func(c *proton.Client) {
 			withMessages(ctx, t, c, "pass", 10000, func(wantMessageIDs []string) {
-				allMessageIDs, err := c.GetMessageIDs(ctx, "")
+				allMessageIDs, err := c.GetAllMessageIDs(ctx, "")
 				require.NoError(t, err)
 				require.ElementsMatch(t, wantMessageIDs, allMessageIDs)
 
-				halfMessageIDs, err := c.GetMessageIDs(ctx, allMessageIDs[len(allMessageIDs)/2])
+				halfMessageIDs, err := c.GetAllMessageIDs(ctx, allMessageIDs[len(allMessageIDs)/2])
 				require.NoError(t, err)
 				require.ElementsMatch(t, allMessageIDs[len(allMessageIDs)/2+1:], halfMessageIDs)
 			})


### PR DESCRIPTION
Add `GetAllMessageIDs` which is the old behavior and add a new function `GetMessageIDs` which only retrieves the given messages up to that limit.