### PR TITLE
fix(GODT-3036): Keep contentID order for attachment in FakeServer.

### DIFF
--- a/server/backend/attachment.go
+++ b/server/backend/attachment.go
@@ -26,6 +26,7 @@ type attachment struct {
 	filename    string
 	mimeType    rfc822.MIMEType
 	disposition proton.Disposition
+	contentID   string
 
 	keyPackets []byte
 	armSig     string
@@ -35,6 +36,7 @@ func newAttachment(
 	filename string,
 	mimeType rfc822.MIMEType,
 	disposition proton.Disposition,
+	contentID string,
 	keyPackets []byte,
 	dataPacketID string,
 	armSig string,
@@ -46,6 +48,7 @@ func newAttachment(
 		filename:    filename,
 		mimeType:    mimeType,
 		disposition: disposition,
+		contentID:   contentID,
 
 		keyPackets: keyPackets,
 		armSig:     armSig,


### PR DESCRIPTION
Inline attachment order is preserved using the attachment contentID.
Message attachment IDs list  should then be computed with contentID properly sorted to ensure inline attachments are rendered in the right order when we get the message from the server.