### PR TITLE
feat(GODT-1224): Add support for clear-signed sending packages

### DIFF
--- a/message_send_types.go
+++ b/message_send_types.go
@@ -137,6 +137,22 @@ func (req *SendDraftReq) AddTextPackage(
 	return nil
 }
 
+func (req *SendDraftReq) AddClearSignedPackage(
+	kr *crypto.KeyRing,
+	body string,
+	prefs map[string]SendPreferences,
+	attKeys map[string]*crypto.SessionKey,
+) error {
+	pkg, err := newClearSignedPackage(kr, body, prefs, attKeys)
+	if err != nil {
+		return err
+	}
+
+	req.Packages = append(req.Packages, pkg)
+
+	return nil
+}
+
 func newMIMEPackage(
 	kr *crypto.KeyRing,
 	mimeBody string,
@@ -200,7 +216,7 @@ func newTextPackage(
 	prefs map[string]SendPreferences,
 	attKeys map[string]*crypto.SessionKey,
 ) (*MessagePackage, error) {
-	if mimeType != rfc822.TextPlain && mimeType != rfc822.TextHTML {
+	if !(mimeType == rfc822.TextPlain || mimeType == rfc822.TextHTML) {
 		return nil, fmt.Errorf("invalid MIME type for package: %s", mimeType)
 	}
 
@@ -217,13 +233,7 @@ func newTextPackage(
 		}
 
 		if prefs.SignatureType == DetachedSignature && !prefs.Encrypt {
-			if prefs.EncryptionScheme == PGPInlineScheme {
-				return nil, fmt.Errorf("invalid encryption scheme for %s: %d", addr, prefs.EncryptionScheme)
-			}
-
-			if prefs.EncryptionScheme == ClearScheme && mimeType != rfc822.TextPlain {
-				return nil, fmt.Errorf("invalid MIME type for clear package: %s", mimeType)
-			}
+			return nil, fmt.Errorf("text package cannot contain clear-signed body")
 		}
 
 		if prefs.EncryptionScheme == InternalScheme && !prefs.Encrypt {
@@ -288,8 +298,63 @@ func newTextPackage(
 	return pkg, nil
 }
 
+func newClearSignedPackage(
+	kr *crypto.KeyRing,
+	body string,
+	prefs map[string]SendPreferences,
+	attKeys map[string]*crypto.SessionKey,
+) (*MessagePackage, error) {
+	encBody, err := kr.Encrypt(crypto.NewPlainMessage([]byte(body)), kr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt MIME body: %w", err)
+	}
+
+	splitEncBody, err := encBody.SplitMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to split message: %w", err)
+	}
+
+	decBodyKey, err := kr.DecryptSessionKey(splitEncBody.GetBinaryKeyPacket())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt session key: %w", err)
+	}
+
+	pkg := newMessagePackage(rfc822.TextPlain, splitEncBody.GetBinaryDataPacket())
+
+	for addr, prefs := range prefs {
+		if prefs.MIMEType != rfc822.TextPlain {
+			return nil, fmt.Errorf("invalid MIME type for clear signed package: %s", prefs.MIMEType)
+		}
+
+		if prefs.SignatureType != DetachedSignature {
+			return nil, fmt.Errorf("clear signed package must contain detached signature")
+		}
+
+		if prefs.Encrypt || prefs.EncryptionScheme != ClearScheme {
+			return nil, fmt.Errorf("clear signed package cannot be encrypted")
+		}
+
+		pkg.BodyKey = newSessionKey(decBodyKey)
+
+		for attID, attKey := range attKeys {
+			pkg.AttachmentKeys[attID] = newSessionKey(attKey)
+		}
+
+		recipient := &MessageRecipient{
+			Type:                 prefs.EncryptionScheme,
+			Signature:            prefs.SignatureType,
+			AttachmentKeyPackets: make(map[string]string),
+		}
+
+		pkg.Addresses[addr] = recipient
+		pkg.Type |= prefs.EncryptionScheme
+	}
+
+	return pkg, nil
+}
+
 func encSplit(kr *crypto.KeyRing, body string) (*crypto.SessionKey, []byte, error) {
-	encBody, err := kr.Encrypt(crypto.NewPlainMessageFromString(body), kr)
+	encBody, err := kr.Encrypt(crypto.NewPlainMessage([]byte(body)), kr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encrypt MIME body: %w", err)
 	}

--- a/message_send_types_test.go
+++ b/message_send_types_test.go
@@ -290,7 +290,7 @@ func TestSendDraftReq_AddPackage(t *testing.T) {
 				EncryptionScheme: proton.ClearScheme,
 				MIMEType:         rfc822.TextPlain,
 			}},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name:     "clear plain text with bad scheme (error)",
@@ -391,17 +391,17 @@ func TestSendDraftReq_AddClearPackage(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    string
-		prefs   map[string]SendPreferences
+		prefs   map[string]proton.SendPreferences
 		attKeys map[string]*crypto.SessionKey
 		wantErr bool
 	}{
 		{
 			name: "clear plain text with signature",
 			body: "this is a text/plain body",
-			prefs: map[string]SendPreferences{"clear-plain-with-sig@email.com": {
+			prefs: map[string]proton.SendPreferences{"clear-plain-with-sig@email.com": {
 				Encrypt:          false,
-				SignatureType:    DetachedSignature,
-				EncryptionScheme: ClearScheme,
+				SignatureType:    proton.DetachedSignature,
+				EncryptionScheme: proton.ClearScheme,
 				MIMEType:         rfc822.TextPlain,
 			}},
 			wantErr: false,
@@ -409,10 +409,10 @@ func TestSendDraftReq_AddClearPackage(t *testing.T) {
 		{
 			name: "clear plain text with bad scheme (error)",
 			body: "this is a text/plain body",
-			prefs: map[string]SendPreferences{"clear-plain-with-sig@email.com": {
+			prefs: map[string]proton.SendPreferences{"clear-plain-with-sig@email.com": {
 				Encrypt:          false,
-				SignatureType:    DetachedSignature,
-				EncryptionScheme: PGPInlineScheme,
+				SignatureType:    proton.DetachedSignature,
+				EncryptionScheme: proton.PGPInlineScheme,
 				MIMEType:         rfc822.TextPlain,
 			}},
 			wantErr: true,
@@ -420,10 +420,10 @@ func TestSendDraftReq_AddClearPackage(t *testing.T) {
 		{
 			name: "clear rich text with signature (error)",
 			body: "this is a text/html body",
-			prefs: map[string]SendPreferences{"clear-plain-with-sig@email.com": {
+			prefs: map[string]proton.SendPreferences{"clear-plain-with-sig@email.com": {
 				Encrypt:          false,
-				SignatureType:    DetachedSignature,
-				EncryptionScheme: ClearScheme,
+				SignatureType:    proton.DetachedSignature,
+				EncryptionScheme: proton.ClearScheme,
 				MIMEType:         rfc822.TextHTML,
 			}},
 			wantErr: true,
@@ -432,7 +432,7 @@ func TestSendDraftReq_AddClearPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var req SendDraftReq
+			var req proton.SendDraftReq
 
 			if err := req.AddClearSignedPackage(kr, tt.body, tt.prefs, tt.attKeys); (err != nil) != tt.wantErr {
 				t.Errorf("SendDraftReq.AddPackage() error = %v, wantErr %v", err, tt.wantErr)

--- a/message_send_types_test.go
+++ b/message_send_types_test.go
@@ -428,6 +428,17 @@ func TestSendDraftReq_AddClearPackage(t *testing.T) {
 			}},
 			wantErr: true,
 		},
+		{
+			name: "clear plain text with signature",
+			body: "this is a text/plain body",
+			prefs: map[string]proton.SendPreferences{"clear-plain-with-sig@email.com": {
+				Encrypt:          true,
+				SignatureType:    proton.DetachedSignature,
+				EncryptionScheme: proton.ClearScheme,
+				MIMEType:         rfc822.TextPlain,
+			}},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add a new send package type for clear-signed messages.
Trailing whitespace is stripped for this package type. The stripping of trailing whitespace has been removed for other package types.