### PR TITLE
fix(GODT-3106): Fix broken import route

### DIFF
--- a/contact_types.go
+++ b/contact_types.go
@@ -278,8 +278,8 @@ type CreateContactsReq struct {
 }
 
 type CreateContactResp struct {
-	Response APIError
-	Contact  Contact
+	APIError
+	Contact Contact
 }
 
 type CreateContactsRes struct {

--- a/helper_test.go
+++ b/helper_test.go
@@ -53,6 +53,6 @@ func createTestMessages(t *testing.T, c *proton.Client, pass string, count int) 
 	require.NoError(t, err)
 
 	for _, res := range res {
-		require.Equal(t, proton.SuccessCode, res.Response.Code)
+		require.Equal(t, proton.SuccessCode, res.Code)
 	}
 }

--- a/manager_report_types.go
+++ b/manager_report_types.go
@@ -57,8 +57,8 @@ type ReportBugAttachmentReq struct {
 }
 
 type ReportBugRes struct {
-	Response APIError
-	Token    *string
+	APIError
+	Token *string
 }
 
 func (req ReportBugReq) toFormData() map[string]string {

--- a/message_import.go
+++ b/message_import.go
@@ -58,8 +58,8 @@ func (c *Client) ImportMessages(ctx context.Context, addrKR *crypto.KeyRing, wor
 			}
 
 			for _, res := range res {
-				if res.Response.Code != SuccessCode {
-					return nil, fmt.Errorf("failed to import message: %w", res.Response)
+				if res.Code != SuccessCode {
+					return nil, fmt.Errorf("failed to import message: %w", res)
 				}
 			}
 

--- a/message_import_types.go
+++ b/message_import_types.go
@@ -26,7 +26,7 @@ type ImportMetadata struct {
 }
 
 type ImportRes struct {
-	Response  APIError
+	APIError
 	MessageID string
 }
 

--- a/server/contacts.go
+++ b/server/contacts.go
@@ -71,7 +71,7 @@ func (s *Server) handlePostContacts() gin.HandlerFunc {
 						proton.CreateContactsRes{
 							Index: i,
 							Response: proton.CreateContactResp{
-								Response: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
+								APIError: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
 							},
 						})
 					continue
@@ -83,7 +83,7 @@ func (s *Server) handlePostContacts() gin.HandlerFunc {
 						proton.CreateContactsRes{
 							Index: i,
 							Response: proton.CreateContactResp{
-								Response: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
+								APIError: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
 							},
 						})
 					continue
@@ -94,7 +94,7 @@ func (s *Server) handlePostContacts() gin.HandlerFunc {
 						proton.CreateContactsRes{
 							Index: i,
 							Response: proton.CreateContactResp{
-								Response: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
+								APIError: proton.APIError{Code: proton.InvalidValue, Message: err.Error()},
 							},
 						})
 					continue
@@ -103,7 +103,7 @@ func (s *Server) handlePostContacts() gin.HandlerFunc {
 					proton.CreateContactsRes{
 						Index: i,
 						Response: proton.CreateContactResp{
-							Response: proton.APIError{Code: proton.SuccessCode},
+							APIError: proton.APIError{Code: proton.SuccessCode},
 							Contact:  contact,
 						},
 					})

--- a/server/messages.go
+++ b/server/messages.go
@@ -297,14 +297,14 @@ func (s *Server) handlePutMailMessagesImport() gin.HandlerFunc {
 			)
 			if err != nil {
 				res.Response = proton.ImportRes{
-					Response: proton.APIError{
+					APIError: proton.APIError{
 						Code:    proton.InvalidValue,
 						Message: fmt.Sprintf("failed to import: %v", err),
 					},
 				}
 			} else {
 				res.Response = proton.ImportRes{
-					Response:  proton.APIError{Code: proton.SuccessCode},
+					APIError:  proton.APIError{Code: proton.SuccessCode},
 					MessageID: messageID,
 				}
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1002,7 +1002,7 @@ func TestServer_Import(t *testing.T) {
 			res := importMessages(ctx, t, c, addr[0].ID, addrKRs[addr[0].ID], []string{}, proton.MessageFlagReceived, 1)
 			require.NoError(t, err)
 			require.Len(t, res, 1)
-			require.Equal(t, proton.SuccessCode, res[0].Response.Code)
+			require.Equal(t, proton.SuccessCode, res[0].Code)
 
 			message, err := c.GetMessage(ctx, res[0].MessageID)
 			require.NoError(t, err)
@@ -1052,7 +1052,7 @@ func TestServer_Import_Dedup(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Len(t, res, 1)
-			require.Equal(t, proton.SuccessCode, res[0].Response.Code)
+			require.Equal(t, proton.SuccessCode, res[0].Code)
 
 			message, err := c.GetMessage(ctx, res[0].MessageID)
 			require.NoError(t, err)
@@ -1075,7 +1075,7 @@ func TestServer_Import_Dedup(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Len(t, resDedup, 1)
-			require.Equal(t, proton.SuccessCode, resDedup[0].Response.Code)
+			require.Equal(t, proton.SuccessCode, resDedup[0].Code)
 			require.Equal(t, res[0].MessageID, resDedup[0].MessageID)
 		})
 	}, WithMessageDedup())
@@ -1444,7 +1444,7 @@ func TestServer_Import_FlagsAndLabels(t *testing.T) {
 						require.Error(t, err)
 					} else {
 						require.NoError(t, err)
-						require.Equal(t, proton.SuccessCode, res[0].Response.Code)
+						require.Equal(t, proton.SuccessCode, res[0].Code)
 
 						message, err := c.GetMessage(ctx, res[0].MessageID)
 						require.NoError(t, err)


### PR DESCRIPTION
The original fixes to parse the HV error message unfortunately caused those corrected error routes to start failing when tested against live proton servers.

Since HV error parsing was improved in a subsequent patch, we no longer needs the original fix and can therefore revert the changes that are causing issues.