### PR TITLE
fix(GODT-3117): Improve Contact Info Retrieval

### DIFF
--- a/contact_card.go
+++ b/contact_card.go
@@ -109,6 +109,17 @@ func (c *Card) Set(kr *crypto.KeyRing, key string, value *vcard.Field) error {
 	return c.encode(kr, dec)
 }
 
+func (c *Card) Add(kr *crypto.KeyRing, key string, value *vcard.Field) error {
+	dec, err := c.decode(kr)
+	if err != nil {
+		return err
+	}
+
+	dec.Add(key, value)
+
+	return c.encode(kr, dec)
+}
+
 func (c *Card) ChangeType(kr *crypto.KeyRing, cardType CardType) error {
 	dec, err := c.decode(kr)
 	if err != nil {

--- a/server/backend/account.go
+++ b/server/backend/account.go
@@ -10,12 +10,13 @@ import (
 )
 
 type account struct {
-	userID       string
-	username     string
-	addresses    map[string]*address
-	mailSettings *mailSettings
-	userSettings proton.UserSettings
-	contacts     map[string]*proton.Contact
+	userID         string
+	username       string
+	addresses      map[string]*address
+	mailSettings   *mailSettings
+	userSettings   proton.UserSettings
+	contacts       map[string]*proton.Contact
+	contactCounter int
 
 	auth     map[string]auth
 	authLock sync.RWMutex

--- a/server/contacts.go
+++ b/server/contacts.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/ProtonMail/go-proton-api"
 	"github.com/ProtonMail/go-proton-api/server/backend"
@@ -10,22 +11,29 @@ import (
 
 func (s *Server) handleGetContacts() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		contacts, err := s.b.GetUserContacts(c.GetString("UserID"))
+		total, contacts, err := s.b.GetUserContacts(c.GetString("UserID"),
+			mustParseInt(c.DefaultQuery("Page", strconv.Itoa(defaultPage))),
+			mustParseInt(c.DefaultQuery("PageSize", strconv.Itoa(defaultPageSize))),
+		)
 		if err != nil {
 			c.AbortWithStatus(http.StatusBadRequest)
 			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{
-			"Code":          proton.MultiCode,
-			"ContactEmails": contacts,
+			"Code":     proton.MultiCode,
+			"Contacts": contacts,
+			"Total":    total,
 		})
 	}
 }
 
 func (s *Server) handleGetContactsEmails() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		contacts, err := s.b.GetUserContactEmails(c.GetString("UserID"), c.GetString("email"))
+		total, contacts, err := s.b.GetUserContactEmails(c.GetString("UserID"), c.Query("Email"),
+			mustParseInt(c.DefaultQuery("Page", strconv.Itoa(defaultPage))),
+			mustParseInt(c.DefaultQuery("PageSize", strconv.Itoa(defaultPageSize))),
+		)
 		if err != nil {
 			c.AbortWithStatus(http.StatusBadRequest)
 			return
@@ -33,6 +41,7 @@ func (s *Server) handleGetContactsEmails() gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{
 			"Code":          proton.MultiCode,
 			"ContactEmails": contacts,
+			"Total":         total,
 		})
 	}
 }


### PR DESCRIPTION
Rather than only fetching the total in on request and discarding all the data, re-use the first page of data and then collect more of them if the data set exceeds the page size.

This patch also includes various fixes to the GPA server to mimic proton server behavior.