### PR TITLE
feat(GODT-3129): Trigger events when address order changes

### DIFF
--- a/server/backend/updates.go
+++ b/server/backend/updates.go
@@ -187,3 +187,16 @@ func (update *userSettingsUpdate) replaces(other update) bool {
 		return false
 	}
 }
+
+type userInfoUpdate struct {
+	baseUpdate
+}
+
+func (update *userInfoUpdate) replaces(other update) bool {
+	switch other.(type) {
+	case *userInfoUpdate:
+		return true
+	default:
+		return false
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -159,6 +159,10 @@ func (s *Server) ChangeAddressAllowSend(userID, addrID string, allowSend bool) e
 	return s.b.ChangeAddressAllowSend(userID, addrID, allowSend)
 }
 
+func (s *Server) SetAddressOrder(userID string, addrIDs []string) error {
+	return s.b.SetAddressOrder(userID, addrIDs)
+}
+
 func (s *Server) ChangeAddressType(userID, addrId string, addrType proton.AddressType) error {
 	return s.b.ChangeAddressType(userID, addrId, addrType)
 }


### PR DESCRIPTION
When changing the address order, trigger address updated events and if the primary address changes, trigger a user info event.