### PR TITLE
fix(GODT-3124): Simplify locking in GPA server

### DIFF
--- a/server/backend/api.go
+++ b/server/backend/api.go
@@ -17,120 +17,146 @@ import (
 )
 
 func (b *Backend) GetUser(userID string) (proton.User, error) {
-	return withAcc(b, userID, func(acc *account) (proton.User, error) {
-		return withMessages(b, func(m map[string]*message) (proton.User, error) {
-			return withAtts(b, func(attachments map[string]*attachment) (proton.User, error) {
-				user := acc.toUser()
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.User, error) {
+		return withAcc(b, userID, func(acc *account) (proton.User, error) {
+			return withMessages(b, func(m map[string]*message) (proton.User, error) {
+				return withAtts(b, func(attachments map[string]*attachment) (proton.User, error) {
+					user := acc.toUser()
 
-				var messageBytes uint64
-				for _, v := range m {
-					if _, ok := acc.addresses[v.addrID]; ok {
-						messageBytes += uint64(len(v.armBody))
-					}
+					var messageBytes uint64
+					for _, v := range m {
+						if _, ok := acc.addresses[v.addrID]; ok {
+							messageBytes += uint64(len(v.armBody))
+						}
 
-					for _, a := range v.attIDs {
-						if attach, ok := attachments[a]; ok {
-							messageBytes += uint64(len(b.attData[attach.attDataID]))
+						for _, a := range v.attIDs {
+							if attach, ok := attachments[a]; ok {
+								messageBytes += uint64(len(b.attData[attach.attDataID]))
+							}
 						}
 					}
-				}
 
-				user.ProductUsedSpace.Mail = messageBytes
+					user.ProductUsedSpace.Mail = messageBytes
 
-				return user, nil
+					return user, nil
+				})
 			})
 		})
 	})
 }
 
 func (b *Backend) GetKeySalts(userID string) ([]proton.Salt, error) {
-	return withAcc(b, userID, func(acc *account) ([]proton.Salt, error) {
-		return xslices.Map(acc.keys, func(key key) proton.Salt {
-			return proton.Salt{
-				ID:      key.keyID,
-				KeySalt: base64.StdEncoding.EncodeToString(acc.salt),
-			}
-		}), nil
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.Salt, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.Salt, error) {
+			return xslices.Map(acc.keys, func(key key) proton.Salt {
+				return proton.Salt{
+					ID:      key.keyID,
+					KeySalt: base64.StdEncoding.EncodeToString(acc.salt),
+				}
+			}), nil
+		})
 	})
 }
 
 func (b *Backend) GetMailSettings(userID string) (proton.MailSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
-		return acc.mailSettings.toMailSettings(), nil
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.MailSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
+			return acc.mailSettings.toMailSettings(), nil
+		})
 	})
 }
 
 func (b *Backend) SetMailSettingsAttachPublicKey(userID string, attach bool) (proton.MailSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
-		acc.mailSettings.attachPubKey = attach
-		return acc.mailSettings.toMailSettings(), nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.MailSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
+			acc.mailSettings.attachPubKey = attach
+			return acc.mailSettings.toMailSettings(), nil
+		})
 	})
 }
 
 func (b *Backend) SetMailSettingsSign(userID string, sign proton.SignExternalMessages) (proton.MailSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
-		acc.mailSettings.sign = sign
-		return acc.mailSettings.toMailSettings(), nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.MailSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
+			acc.mailSettings.sign = sign
+			return acc.mailSettings.toMailSettings(), nil
+		})
 	})
 }
 
 func (b *Backend) SetMailSettingsDraftMIMEType(userID string, drafttype rfc822.MIMEType) (proton.MailSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
-		acc.mailSettings.draftMIMEType = drafttype
-		return acc.mailSettings.toMailSettings(), nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.MailSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
+			acc.mailSettings.draftMIMEType = drafttype
+			return acc.mailSettings.toMailSettings(), nil
+		})
 	})
 }
 
 func (b *Backend) SetMailSettingsPGPScheme(userID string, scheme proton.EncryptionScheme) (proton.MailSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
-		acc.mailSettings.pgpScheme = scheme
-		return acc.mailSettings.toMailSettings(), nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.MailSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.MailSettings, error) {
+			acc.mailSettings.pgpScheme = scheme
+			return acc.mailSettings.toMailSettings(), nil
+		})
 	})
 }
 
 func (b *Backend) GetUserSettings(userID string) (proton.UserSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
-		return acc.userSettings, nil
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.UserSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
+			return acc.userSettings, nil
+		})
 	})
 }
 
 func (b *Backend) SetUserSettingsTelemetry(userID string, telemetry proton.SettingsBool) (proton.UserSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
-		if telemetry != proton.SettingDisabled && telemetry != proton.SettingEnabled {
-			return proton.UserSettings{}, errors.New("bad value")
-		}
-		acc.userSettings.Telemetry = telemetry
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.UserSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
+			if telemetry != proton.SettingDisabled && telemetry != proton.SettingEnabled {
+				return proton.UserSettings{}, errors.New("bad value")
+			}
+			acc.userSettings.Telemetry = telemetry
 
-		updateID, err := b.newUpdate(&userSettingsUpdate{settings: acc.userSettings})
-		if err != nil {
-			return acc.userSettings, err
-		}
+			updateID, err := b.newUpdate(&userSettingsUpdate{settings: acc.userSettings})
+			if err != nil {
+				return acc.userSettings, err
+			}
 
-		acc.updateIDs = append(acc.updateIDs, updateID)
+			acc.updateIDs = append(acc.updateIDs, updateID)
 
-		return acc.userSettings, nil
+			return acc.userSettings, nil
+		})
 	})
 }
 
 func (b *Backend) SetUserSettingsCrashReports(userID string, crashReports proton.SettingsBool) (proton.UserSettings, error) {
-	return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
-		if crashReports != proton.SettingDisabled && crashReports != proton.SettingEnabled {
-			return proton.UserSettings{}, errors.New("bad value")
-		}
-		acc.userSettings.CrashReports = crashReports
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.UserSettings, error) {
+		return withAcc(b, userID, func(acc *account) (proton.UserSettings, error) {
+			if crashReports != proton.SettingDisabled && crashReports != proton.SettingEnabled {
+				return proton.UserSettings{}, errors.New("bad value")
+			}
+			acc.userSettings.CrashReports = crashReports
 
-		updateID, err := b.newUpdate(&userSettingsUpdate{settings: acc.userSettings})
-		if err != nil {
-			return acc.userSettings, err
-		}
+			updateID, err := b.newUpdate(&userSettingsUpdate{settings: acc.userSettings})
+			if err != nil {
+				return acc.userSettings, err
+			}
 
-		acc.updateIDs = append(acc.updateIDs, updateID)
+			acc.updateIDs = append(acc.updateIDs, updateID)
 
-		return acc.userSettings, nil
+			return acc.userSettings, nil
+		})
 	})
 }
 
 func (b *Backend) GetAddressID(email string) (string, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return b.getAddressID(email)
+	})
+}
+
+func (b *unsafeBackend) getAddressID(email string) (string, error) {
 	return withAccEmail(b, email, func(acc *account) (string, error) {
 		addr, ok := acc.getAddr(email)
 		if !ok {
@@ -142,103 +168,115 @@ func (b *Backend) GetAddressID(email string) (string, error) {
 }
 
 func (b *Backend) GetAddress(userID, addrID string) (proton.Address, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Address, error) {
-		if addr, ok := acc.addresses[addrID]; ok {
-			return addr.toAddress(), nil
-		}
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.Address, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Address, error) {
+			if addr, ok := acc.addresses[addrID]; ok {
+				return addr.toAddress(), nil
+			}
 
-		return proton.Address{}, errors.New("no such address")
+			return proton.Address{}, errors.New("no such address")
+		})
 	})
 }
 
 func (b *Backend) GetAddresses(userID string) ([]proton.Address, error) {
-	return withAcc(b, userID, func(acc *account) ([]proton.Address, error) {
-		return xslices.Map(maps.Values(acc.addresses), func(add *address) proton.Address {
-			return add.toAddress()
-		}), nil
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.Address, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.Address, error) {
+			return xslices.Map(maps.Values(acc.addresses), func(add *address) proton.Address {
+				return add.toAddress()
+			}), nil
+		})
 	})
 }
 
 func (b *Backend) EnableAddress(userID, addrID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		acc.addresses[addrID].status = proton.AddressStatusEnabled
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			acc.addresses[addrID].status = proton.AddressStatusEnabled
 
-		updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) DisableAddress(userID, addrID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		acc.addresses[addrID].status = proton.AddressStatusDisabled
-
-		updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) DeleteAddress(userID, addrID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		if acc.addresses[addrID].status != proton.AddressStatusDisabled {
-			return errors.New("address is not disabled")
-		}
-
-		delete(acc.addresses, addrID)
-
-		updateID, err := b.newUpdate(&addressDeleted{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) SetAddressOrder(userID string, addrIDs []string) error {
-	return b.withAcc(userID, func(acc *account) error {
-
-		primaryID := acc.primary().addrID
-
-		for i, addrID := range addrIDs {
-			if add, ok := acc.addresses[addrID]; ok {
-				if add.order != i+1 {
-					updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
-					if err != nil {
-						return err
-					}
-
-					acc.updateIDs = append(acc.updateIDs, updateID)
-				}
-				add.order = i + 1
-			} else {
-				return fmt.Errorf("no such address: %s", addrID)
-			}
-		}
-
-		if primaryID != acc.primary().addrID {
-			updateID, err := b.newUpdate(&userInfoUpdate{})
+			updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
 			if err != nil {
 				return err
 			}
 
 			acc.updateIDs = append(acc.updateIDs, updateID)
-		}
 
-		return nil
+			return nil
+		})
+	})
+}
+
+func (b *Backend) DisableAddress(userID, addrID string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			acc.addresses[addrID].status = proton.AddressStatusDisabled
+
+			updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
+		})
+	})
+}
+
+func (b *Backend) DeleteAddress(userID, addrID string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			if acc.addresses[addrID].status != proton.AddressStatusDisabled {
+				return errors.New("address is not disabled")
+			}
+
+			delete(acc.addresses, addrID)
+
+			updateID, err := b.newUpdate(&addressDeleted{addressID: addrID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
+		})
+	})
+}
+
+func (b *Backend) SetAddressOrder(userID string, addrIDs []string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+
+			primaryID := acc.primary().addrID
+
+			for i, addrID := range addrIDs {
+				if add, ok := acc.addresses[addrID]; ok {
+					if add.order != i+1 {
+						updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
+						if err != nil {
+							return err
+						}
+
+						acc.updateIDs = append(acc.updateIDs, updateID)
+					}
+					add.order = i + 1
+				} else {
+					return fmt.Errorf("no such address: %s", addrID)
+				}
+			}
+
+			if primaryID != acc.primary().addrID {
+				updateID, err := b.newUpdate(&userInfoUpdate{})
+				if err != nil {
+					return err
+				}
+
+				acc.updateIDs = append(acc.updateIDs, updateID)
+			}
+
+			return nil
+		})
 	})
 }
 
@@ -273,323 +311,128 @@ func (b *Backend) GetLabel(userID, labelID string) (proton.Label, error) {
 }
 
 func (b *Backend) GetLabels(userID string, types ...proton.LabelType) ([]proton.Label, error) {
-	return withAcc(b, userID, func(acc *account) ([]proton.Label, error) {
-		return withLabels(b, func(labels map[string]*label) ([]proton.Label, error) {
-			res := xslices.Map(acc.labelIDs, func(labelID string) proton.Label {
-				return labels[labelID].toLabel(labels)
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.Label, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.Label, error) {
+			return withLabels(b, func(labels map[string]*label) ([]proton.Label, error) {
+				res := xslices.Map(acc.labelIDs, func(labelID string) proton.Label {
+					return labels[labelID].toLabel(labels)
+				})
+
+				for labelName, labelID := range map[string]string{
+					"Inbox":     proton.InboxLabel,
+					"AllDrafts": proton.AllDraftsLabel,
+					"AllSent":   proton.AllSentLabel,
+					"Trash":     proton.TrashLabel,
+					"Spam":      proton.SpamLabel,
+					"All Mail":  proton.AllMailLabel,
+					"Archive":   proton.ArchiveLabel,
+					"Sent":      proton.SentLabel,
+					"Drafts":    proton.DraftsLabel,
+					"Outbox":    proton.OutboxLabel,
+					"Starred":   proton.StarredLabel,
+					"Scheduled": proton.AllScheduledLabel,
+				} {
+					res = append(res, proton.Label{
+						ID:   labelID,
+						Name: labelName,
+						Path: []string{labelName},
+						Type: proton.LabelTypeSystem,
+					})
+				}
+
+				if len(types) > 0 {
+					res = xslices.Filter(res, func(label proton.Label) bool {
+						return slices.Contains(types, label.Type)
+					})
+				}
+
+				return res, nil
 			})
-
-			for labelName, labelID := range map[string]string{
-				"Inbox":     proton.InboxLabel,
-				"AllDrafts": proton.AllDraftsLabel,
-				"AllSent":   proton.AllSentLabel,
-				"Trash":     proton.TrashLabel,
-				"Spam":      proton.SpamLabel,
-				"All Mail":  proton.AllMailLabel,
-				"Archive":   proton.ArchiveLabel,
-				"Sent":      proton.SentLabel,
-				"Drafts":    proton.DraftsLabel,
-				"Outbox":    proton.OutboxLabel,
-				"Starred":   proton.StarredLabel,
-				"Scheduled": proton.AllScheduledLabel,
-			} {
-				res = append(res, proton.Label{
-					ID:   labelID,
-					Name: labelName,
-					Path: []string{labelName},
-					Type: proton.LabelTypeSystem,
-				})
-			}
-
-			if len(types) > 0 {
-				res = xslices.Filter(res, func(label proton.Label) bool {
-					return slices.Contains(types, label.Type)
-				})
-			}
-
-			return res, nil
 		})
+
 	})
 }
 
 func (b *Backend) CreateLabel(userID, labelName, parentID string, labelType proton.LabelType) (proton.Label, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Label, error) {
-		return withLabels(b, func(labels map[string]*label) (proton.Label, error) {
-			if parentID != "" {
-				if labelType != proton.LabelTypeFolder {
-					return proton.Label{}, fmt.Errorf("parentID can only be set for folders")
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Label, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Label, error) {
+			return withLabels(b, func(labels map[string]*label) (proton.Label, error) {
+				if parentID != "" {
+					if labelType != proton.LabelTypeFolder {
+						return proton.Label{}, fmt.Errorf("parentID can only be set for folders")
+					}
+
+					if _, ok := labels[parentID]; !ok {
+						return proton.Label{}, fmt.Errorf("no such parent label: %s", parentID)
+					}
 				}
 
-				if _, ok := labels[parentID]; !ok {
-					return proton.Label{}, fmt.Errorf("no such parent label: %s", parentID)
+				label := newLabel(labelName, parentID, labelType)
+
+				labels[label.labelID] = label
+
+				updateID, err := b.newUpdate(&labelCreated{labelID: label.labelID})
+				if err != nil {
+					return proton.Label{}, err
 				}
-			}
 
-			label := newLabel(labelName, parentID, labelType)
+				acc.labelIDs = append(acc.labelIDs, label.labelID)
+				acc.updateIDs = append(acc.updateIDs, updateID)
 
-			labels[label.labelID] = label
-
-			updateID, err := b.newUpdate(&labelCreated{labelID: label.labelID})
-			if err != nil {
-				return proton.Label{}, err
-			}
-
-			acc.labelIDs = append(acc.labelIDs, label.labelID)
-			acc.updateIDs = append(acc.updateIDs, updateID)
-
-			return label.toLabel(labels), nil
+				return label.toLabel(labels), nil
+			})
 		})
 	})
 }
 
 func (b *Backend) UpdateLabel(userID, labelID, name, parentID string) (proton.Label, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Label, error) {
-		return withLabels(b, func(labels map[string]*label) (proton.Label, error) {
-			if parentID != "" {
-				if labels[labelID].labelType != proton.LabelTypeFolder {
-					return proton.Label{}, fmt.Errorf("parentID can only be set for folders")
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Label, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Label, error) {
+			return withLabels(b, func(labels map[string]*label) (proton.Label, error) {
+				if parentID != "" {
+					if labels[labelID].labelType != proton.LabelTypeFolder {
+						return proton.Label{}, fmt.Errorf("parentID can only be set for folders")
+					}
+
+					if _, ok := labels[parentID]; !ok {
+						return proton.Label{}, fmt.Errorf("no such parent label: %s", parentID)
+					}
 				}
 
-				if _, ok := labels[parentID]; !ok {
-					return proton.Label{}, fmt.Errorf("no such parent label: %s", parentID)
+				labels[labelID].name = name
+				labels[labelID].parentID = parentID
+
+				updateID, err := b.newUpdate(&labelUpdated{labelID: labelID})
+				if err != nil {
+					return proton.Label{}, err
 				}
-			}
 
-			labels[labelID].name = name
-			labels[labelID].parentID = parentID
+				acc.updateIDs = append(acc.updateIDs, updateID)
 
-			updateID, err := b.newUpdate(&labelUpdated{labelID: labelID})
-			if err != nil {
-				return proton.Label{}, err
-			}
-
-			acc.updateIDs = append(acc.updateIDs, updateID)
-
-			return labels[labelID].toLabel(labels), nil
+				return labels[labelID].toLabel(labels), nil
+			})
 		})
 	})
 }
 
 func (b *Backend) DeleteLabel(userID, labelID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withLabels(func(labels map[string]*label) error {
-			if _, ok := labels[labelID]; !ok {
-				return errors.New("label not found")
-			}
-
-			for _, labelID := range getLabelIDsToDelete(labelID, labels) {
-				delete(labels, labelID)
-
-				updateID, err := b.newUpdate(&labelDeleted{labelID: labelID})
-				if err != nil {
-					return err
-				}
-
-				acc.labelIDs = xslices.Filter(acc.labelIDs, func(otherID string) bool { return otherID != labelID })
-				acc.updateIDs = append(acc.updateIDs, updateID)
-			}
-
-			return nil
-		})
-	})
-}
-
-func (b *Backend) CountMessages(userID string) (int, error) {
-	return withAcc(b, userID, func(acc *account) (int, error) {
-		return len(acc.messageIDs), nil
-	})
-}
-
-func (b *Backend) GetMessageIDs(userID string, afterID string, limit int) ([]string, error) {
-	return withAcc(b, userID, func(acc *account) ([]string, error) {
-		if len(acc.messageIDs) == 0 {
-			return nil, nil
-		}
-
-		var lo, hi int
-
-		if afterID == "" {
-			lo = 0
-		} else {
-			lo = slices.Index(acc.messageIDs, afterID) + 1
-		}
-
-		if limit == 0 {
-			hi = len(acc.messageIDs)
-		} else {
-			hi = lo + limit
-
-			if hi > len(acc.messageIDs) {
-				hi = len(acc.messageIDs)
-			}
-		}
-
-		return acc.messageIDs[lo:hi], nil
-	})
-}
-
-func (b *Backend) GetMessages(userID string, page, pageSize int, filter proton.MessageFilter) ([]proton.MessageMetadata, error) {
-	return withAcc(b, userID, func(acc *account) ([]proton.MessageMetadata, error) {
-		return withMessages(b, func(messages map[string]*message) ([]proton.MessageMetadata, error) {
-			metadata, err := withAtts(b, func(atts map[string]*attachment) ([]proton.MessageMetadata, error) {
-				return xslices.Map(acc.messageIDs, func(messageID string) proton.MessageMetadata {
-					return messages[messageID].toMetadata(b.attData, atts)
-				}), nil
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			if filter.Desc {
-				xslices.Reverse(metadata)
-			}
-
-			// Note that this not a perfect replacement as we don't handle the case where this message could have been
-			// deleted in between this metadata request. The backend has the information stored differently and can
-			// resolve these gaps.
-			if filter.EndID != "" {
-				index := xslices.IndexFunc(metadata, func(metadata proton.MessageMetadata) bool {
-					return metadata.ID == filter.EndID
-				})
-
-				if index >= 0 {
-					metadata = metadata[index:]
-				}
-			}
-
-			metadata = xslices.Filter(metadata, func(metadata proton.MessageMetadata) bool {
-				if len(filter.ID) > 0 {
-					if !slices.Contains(filter.ID, metadata.ID) {
-						return false
-					}
-				}
-
-				if filter.Subject != "" {
-					if !strings.Contains(metadata.Subject, filter.Subject) {
-						return false
-					}
-				}
-
-				if filter.AddressID != "" {
-					if filter.AddressID != metadata.AddressID {
-						return false
-					}
-				}
-
-				if filter.ExternalID != "" {
-					if filter.ExternalID != metadata.ExternalID {
-						return false
-					}
-				}
-
-				if filter.LabelID != "" {
-					if !slices.Contains(metadata.LabelIDs, filter.LabelID) {
-						return false
-					}
-				}
-
-				return true
-			})
-
-			pages := xslices.Chunk(metadata, pageSize)
-			if page >= len(pages) {
-				return nil, nil
-			}
-
-			return pages[page], nil
-		})
-	})
-}
-
-func (b *Backend) GetMessage(userID, messageID string) (proton.Message, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Message, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
-			return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
-				message, ok := messages[messageID]
-				if !ok {
-					return proton.Message{}, errors.New("no such message")
-				}
-
-				return message.toMessage(b.attData, atts), nil
-			})
-		})
-	})
-}
-
-func (b *Backend) SetMessagesRead(userID string, read bool, messageIDs ...string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(messages map[string]*message) error {
-			for _, messageID := range messageIDs {
-				messages[messageID].unread = !read
-
-				updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
-				if err != nil {
-					return err
-				}
-
-				acc.updateIDs = append(acc.updateIDs, updateID)
-			}
-
-			return nil
-		})
-	})
-}
-
-func (b *Backend) SetMessagesForwarded(userID string, forwarded bool, messageIDs ...string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(messages map[string]*message) error {
-			for _, messageID := range messageIDs {
-				if forwarded {
-					messages[messageID].flags |= proton.MessageFlagForwarded
-				} else {
-					messages[messageID].flags &= ^proton.MessageFlagForwarded
-				}
-
-				updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
-				if err != nil {
-					return err
-				}
-
-				acc.updateIDs = append(acc.updateIDs, updateID)
-			}
-
-			return nil
-		})
-	})
-}
-
-func (b *Backend) LabelMessages(userID, labelID string, messageIDs ...string) error {
-	return b.labelMessages(userID, labelID, true, messageIDs...)
-}
-
-func (b *Backend) LabelMessagesNoEvents(userID, labelID string, messageIDs ...string) error {
-	return b.labelMessages(userID, labelID, false, messageIDs...)
-}
-
-func (b *Backend) labelMessages(userID, labelID string, doEvents bool, messageIDs ...string) error {
-	if labelID == proton.AllMailLabel || labelID == proton.AllDraftsLabel || labelID == proton.AllSentLabel {
-		return fmt.Errorf("not allowed")
-	}
-
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(messages map[string]*message) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
 			return b.withLabels(func(labels map[string]*label) error {
-				for _, messageID := range messageIDs {
-					message, ok := messages[messageID]
-					if !ok {
-						continue
+				if _, ok := labels[labelID]; !ok {
+					return errors.New("label not found")
+				}
+
+				for _, labelID := range getLabelIDsToDelete(labelID, labels) {
+					delete(labels, labelID)
+
+					updateID, err := b.newUpdate(&labelDeleted{labelID: labelID})
+					if err != nil {
+						return err
 					}
 
-					message.addLabel(labelID, labels)
-
-					if doEvents {
-						updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
-						if err != nil {
-							return err
-						}
-
-						acc.updateIDs = append(acc.updateIDs, updateID)
-					}
+					acc.labelIDs = xslices.Filter(acc.labelIDs, func(otherID string) bool { return otherID != labelID })
+					acc.updateIDs = append(acc.updateIDs, updateID)
 				}
 
 				return nil
@@ -598,16 +441,142 @@ func (b *Backend) labelMessages(userID, labelID string, doEvents bool, messageID
 	})
 }
 
-func (b *Backend) UnlabelMessages(userID, labelID string, messageIDs ...string) error {
-	if labelID == proton.AllMailLabel || labelID == proton.AllDraftsLabel || labelID == proton.AllSentLabel {
-		return fmt.Errorf("not allowed")
-	}
+func (b *Backend) CountMessages(userID string) (int, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) (int, error) {
+		return withAcc(b, userID, func(acc *account) (int, error) {
+			return len(acc.messageIDs), nil
+		})
+	})
+}
 
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(messages map[string]*message) error {
-			return b.withLabels(func(labels map[string]*label) error {
+func (b *Backend) GetMessageIDs(userID string, afterID string, limit int) ([]string, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]string, error) {
+		return withAcc(b, userID, func(acc *account) ([]string, error) {
+			if len(acc.messageIDs) == 0 {
+				return nil, nil
+			}
+
+			var lo, hi int
+
+			if afterID == "" {
+				lo = 0
+			} else {
+				lo = slices.Index(acc.messageIDs, afterID) + 1
+			}
+
+			if limit == 0 {
+				hi = len(acc.messageIDs)
+			} else {
+				hi = lo + limit
+
+				if hi > len(acc.messageIDs) {
+					hi = len(acc.messageIDs)
+				}
+			}
+
+			return acc.messageIDs[lo:hi], nil
+		})
+	})
+}
+
+func (b *Backend) GetMessages(userID string, page, pageSize int, filter proton.MessageFilter) ([]proton.MessageMetadata, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.MessageMetadata, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.MessageMetadata, error) {
+			return withMessages(b, func(messages map[string]*message) ([]proton.MessageMetadata, error) {
+				metadata, err := withAtts(b, func(atts map[string]*attachment) ([]proton.MessageMetadata, error) {
+					return xslices.Map(acc.messageIDs, func(messageID string) proton.MessageMetadata {
+						return messages[messageID].toMetadata(b.attData, atts)
+					}), nil
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				if filter.Desc {
+					xslices.Reverse(metadata)
+				}
+
+				// Note that this not a perfect replacement as we don't handle the case where this message could have been
+				// deleted in between this metadata request. The backend has the information stored differently and can
+				// resolve these gaps.
+				if filter.EndID != "" {
+					index := xslices.IndexFunc(metadata, func(metadata proton.MessageMetadata) bool {
+						return metadata.ID == filter.EndID
+					})
+
+					if index >= 0 {
+						metadata = metadata[index:]
+					}
+				}
+
+				metadata = xslices.Filter(metadata, func(metadata proton.MessageMetadata) bool {
+					if len(filter.ID) > 0 {
+						if !slices.Contains(filter.ID, metadata.ID) {
+							return false
+						}
+					}
+
+					if filter.Subject != "" {
+						if !strings.Contains(metadata.Subject, filter.Subject) {
+							return false
+						}
+					}
+
+					if filter.AddressID != "" {
+						if filter.AddressID != metadata.AddressID {
+							return false
+						}
+					}
+
+					if filter.ExternalID != "" {
+						if filter.ExternalID != metadata.ExternalID {
+							return false
+						}
+					}
+
+					if filter.LabelID != "" {
+						if !slices.Contains(metadata.LabelIDs, filter.LabelID) {
+							return false
+						}
+					}
+
+					return true
+				})
+
+				pages := xslices.Chunk(metadata, pageSize)
+				if page >= len(pages) {
+					return nil, nil
+				}
+
+				return pages[page], nil
+			})
+		})
+	})
+}
+
+func (b *Backend) GetMessage(userID, messageID string) (proton.Message, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.Message, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Message, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
+				return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
+					message, ok := messages[messageID]
+					if !ok {
+						return proton.Message{}, errors.New("no such message")
+					}
+
+					return message.toMessage(b.attData, atts), nil
+				})
+			})
+		})
+	})
+}
+
+func (b *Backend) SetMessagesRead(userID string, read bool, messageIDs ...string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(messages map[string]*message) error {
 				for _, messageID := range messageIDs {
-					messages[messageID].remLabel(labelID, labels)
+					messages[messageID].unread = !read
 
 					updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
 					if err != nil {
@@ -623,214 +592,317 @@ func (b *Backend) UnlabelMessages(userID, labelID string, messageIDs ...string) 
 	})
 }
 
-func (b *Backend) DeleteMessage(userID, messageID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(messages map[string]*message) error {
-			message, ok := messages[messageID]
-			if !ok {
-				return errors.New("no such message")
-			}
-
-			for _, attID := range message.attIDs {
-				if xslices.CountFunc(maps.Values(b.attachments), func(att *attachment) bool {
-					return att.attDataID == b.attachments[attID].attDataID
-				}) == 1 {
-					delete(b.attData, b.attachments[attID].attDataID)
-				}
-
-				delete(b.attachments, attID)
-			}
-
-			delete(b.messages, messageID)
-
-			updateID, err := b.newUpdate(&messageDeleted{messageID: messageID})
-			if err != nil {
-				return err
-			}
-
-			acc.messageIDs = xslices.Filter(acc.messageIDs, func(otherID string) bool { return otherID != messageID })
-			acc.updateIDs = append(acc.updateIDs, updateID)
-
-			return nil
-		})
-	})
-}
-
-func (b *Backend) CreateDraft(userID, addrID string, draft proton.DraftTemplate, parentID string, action proton.CreateDraftAction) (proton.Message, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Message, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
-			return withLabels(b, func(labels map[string]*label) (proton.Message, error) {
-				// Convert the parentID into externalRef.\
-				var parentRef string
-				var internalParentID string
-				if parentID != "" {
-					parentMsg, ok := messages[parentID]
-					if ok {
-						parentRef = "<" + parentMsg.externalID + ">"
-						internalParentID = parentID
+func (b *Backend) SetMessagesForwarded(userID string, forwarded bool, messageIDs ...string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(messages map[string]*message) error {
+				for _, messageID := range messageIDs {
+					if forwarded {
+						messages[messageID].flags |= proton.MessageFlagForwarded
+					} else {
+						messages[messageID].flags &= ^proton.MessageFlagForwarded
 					}
-				}
-				msg := newMessageFromTemplate(addrID, draft, parentRef, internalParentID, action)
-				// Drafts automatically get the sysLabel "Drafts".
-				msg.addLabel(proton.DraftsLabel, labels)
 
-				messages[msg.messageID] = msg
+					updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
+					if err != nil {
+						return err
+					}
 
-				updateID, err := b.newUpdate(&messageCreated{messageID: msg.messageID})
-				if err != nil {
-					return proton.Message{}, err
+					acc.updateIDs = append(acc.updateIDs, updateID)
 				}
 
-				acc.messageIDs = append(acc.messageIDs, msg.messageID)
-				acc.updateIDs = append(acc.updateIDs, updateID)
-
-				return msg.toMessage(nil, nil), nil
+				return nil
 			})
 		})
 	})
 }
 
-func (b *Backend) UpdateDraft(userID, draftID string, changes proton.DraftTemplate) (proton.Message, error) {
-	if changes.Sender == nil {
-		return proton.Message{}, errors.New("the Sender is required")
-	}
-
-	if changes.Sender.Address == "" {
-		return proton.Message{}, errors.New("the Address is required")
-	}
-
-	if changes.MIMEType != rfc822.TextPlain && changes.MIMEType != rfc822.TextHTML {
-		return proton.Message{}, errors.New("the MIMEType must be text/plain or text/html")
-	}
-
-	return withAcc(b, userID, func(acc *account) (proton.Message, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
-			return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
-				if _, ok := messages[draftID]; !ok {
-					return proton.Message{}, fmt.Errorf("message %q not found", draftID)
-				}
-
-				messages[draftID].applyChanges(changes)
-
-				updateID, err := b.newUpdate(&messageUpdated{messageID: draftID})
-				if err != nil {
-					return proton.Message{}, err
-				}
-
-				acc.updateIDs = append(acc.updateIDs, updateID)
-
-				return messages[draftID].toMessage(b.attData, atts), nil
-			})
-		})
-	})
+func (b *Backend) LabelMessages(userID, labelID string, messageIDs ...string) error {
+	return b.labelMessages(userID, labelID, true, messageIDs...)
 }
 
-func (b *Backend) SendMessage(userID, messageID string, packages []*proton.MessagePackage) (proton.Message, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Message, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
-			return withLabels(b, func(labels map[string]*label) (proton.Message, error) {
-				return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
-					msg := messages[messageID]
-					msg.flags |= proton.MessageFlagSent
-					msg.addLabel(proton.SentLabel, labels)
+func (b *Backend) LabelMessagesNoEvents(userID, labelID string, messageIDs ...string) error {
+	return b.labelMessages(userID, labelID, false, messageIDs...)
+}
 
-					if parent, ok := messages[msg.internalParentID]; ok {
-						switch msg.draftAction {
-						case proton.ReplyAction:
-							parent.flags |= proton.MessageFlagReplied
-						case proton.ReplyAllAction:
-							parent.flags |= proton.MessageFlagRepliedAll
-						case proton.ForwardAction:
-							parent.flags |= proton.MessageFlagForwarded
+func (b *Backend) labelMessages(userID, labelID string, doEvents bool, messageIDs ...string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		if labelID == proton.AllMailLabel || labelID == proton.AllDraftsLabel || labelID == proton.AllSentLabel {
+			return fmt.Errorf("not allowed")
+		}
+
+		return b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(messages map[string]*message) error {
+				return b.withLabels(func(labels map[string]*label) error {
+					for _, messageID := range messageIDs {
+						message, ok := messages[messageID]
+						if !ok {
+							continue
 						}
 
-						updateID, err := b.newUpdate(&messageUpdated{messageID: msg.internalParentID})
+						message.addLabel(labelID, labels)
+
+						if doEvents {
+							updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
+							if err != nil {
+								return err
+							}
+
+							acc.updateIDs = append(acc.updateIDs, updateID)
+						}
+					}
+
+					return nil
+				})
+			})
+		})
+	})
+}
+
+func (b *Backend) UnlabelMessages(userID, labelID string, messageIDs ...string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		if labelID == proton.AllMailLabel || labelID == proton.AllDraftsLabel || labelID == proton.AllSentLabel {
+			return fmt.Errorf("not allowed")
+		}
+
+		return b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(messages map[string]*message) error {
+				return b.withLabels(func(labels map[string]*label) error {
+					for _, messageID := range messageIDs {
+						messages[messageID].remLabel(labelID, labels)
+
+						updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
 						if err != nil {
-							return proton.Message{}, err
+							return err
 						}
 
 						acc.updateIDs = append(acc.updateIDs, updateID)
 					}
 
-					updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
+					return nil
+				})
+			})
+		})
+	})
+}
+
+func (b *Backend) DeleteMessage(userID, messageID string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(messages map[string]*message) error {
+				message, ok := messages[messageID]
+				if !ok {
+					return errors.New("no such message")
+				}
+
+				for _, attID := range message.attIDs {
+					if xslices.CountFunc(maps.Values(b.attachments), func(att *attachment) bool {
+						return att.attDataID == b.attachments[attID].attDataID
+					}) == 1 {
+						delete(b.attData, b.attachments[attID].attDataID)
+					}
+
+					delete(b.attachments, attID)
+				}
+
+				delete(b.messages, messageID)
+
+				updateID, err := b.newUpdate(&messageDeleted{messageID: messageID})
+				if err != nil {
+					return err
+				}
+
+				acc.messageIDs = xslices.Filter(acc.messageIDs, func(otherID string) bool { return otherID != messageID })
+				acc.updateIDs = append(acc.updateIDs, updateID)
+
+				return nil
+			})
+		})
+	})
+}
+
+func (b *Backend) CreateDraft(userID, addrID string, draft proton.DraftTemplate, parentID string, action proton.CreateDraftAction) (proton.Message, error) {
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Message, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Message, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
+				return withLabels(b, func(labels map[string]*label) (proton.Message, error) {
+					// Convert the parentID into externalRef.\
+					var parentRef string
+					var internalParentID string
+					if parentID != "" {
+						parentMsg, ok := messages[parentID]
+						if ok {
+							parentRef = "<" + parentMsg.externalID + ">"
+							internalParentID = parentID
+						}
+					}
+					msg := newMessageFromTemplate(addrID, draft, parentRef, internalParentID, action)
+					// Drafts automatically get the sysLabel "Drafts".
+					msg.addLabel(proton.DraftsLabel, labels)
+
+					messages[msg.messageID] = msg
+
+					updateID, err := b.newUpdate(&messageCreated{messageID: msg.messageID})
+					if err != nil {
+						return proton.Message{}, err
+					}
+
+					acc.messageIDs = append(acc.messageIDs, msg.messageID)
+					acc.updateIDs = append(acc.updateIDs, updateID)
+
+					return msg.toMessage(nil, nil), nil
+				})
+			})
+		})
+
+	})
+}
+
+func (b *Backend) UpdateDraft(userID, draftID string, changes proton.DraftTemplate) (proton.Message, error) {
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Message, error) {
+		if changes.Sender == nil {
+			return proton.Message{}, errors.New("the Sender is required")
+		}
+
+		if changes.Sender.Address == "" {
+			return proton.Message{}, errors.New("the Address is required")
+		}
+
+		if changes.MIMEType != rfc822.TextPlain && changes.MIMEType != rfc822.TextHTML {
+			return proton.Message{}, errors.New("the MIMEType must be text/plain or text/html")
+		}
+
+		return withAcc(b, userID, func(acc *account) (proton.Message, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
+				return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
+					if _, ok := messages[draftID]; !ok {
+						return proton.Message{}, fmt.Errorf("message %q not found", draftID)
+					}
+
+					messages[draftID].applyChanges(changes)
+
+					updateID, err := b.newUpdate(&messageUpdated{messageID: draftID})
 					if err != nil {
 						return proton.Message{}, err
 					}
 
 					acc.updateIDs = append(acc.updateIDs, updateID)
 
-					for _, pkg := range packages {
-						bodyData, err := base64.StdEncoding.DecodeString(pkg.Body)
+					return messages[draftID].toMessage(b.attData, atts), nil
+				})
+			})
+		})
+	})
+}
+
+func (b *Backend) SendMessage(userID, messageID string, packages []*proton.MessagePackage) (proton.Message, error) {
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Message, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Message, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Message, error) {
+				return withLabels(b, func(labels map[string]*label) (proton.Message, error) {
+					return withAtts(b, func(atts map[string]*attachment) (proton.Message, error) {
+						msg := messages[messageID]
+						msg.flags |= proton.MessageFlagSent
+						msg.addLabel(proton.SentLabel, labels)
+
+						if parent, ok := messages[msg.internalParentID]; ok {
+							switch msg.draftAction {
+							case proton.ReplyAction:
+								parent.flags |= proton.MessageFlagReplied
+							case proton.ReplyAllAction:
+								parent.flags |= proton.MessageFlagRepliedAll
+							case proton.ForwardAction:
+								parent.flags |= proton.MessageFlagForwarded
+							}
+
+							updateID, err := b.newUpdate(&messageUpdated{messageID: msg.internalParentID})
+							if err != nil {
+								return proton.Message{}, err
+							}
+
+							acc.updateIDs = append(acc.updateIDs, updateID)
+						}
+
+						updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
 						if err != nil {
 							return proton.Message{}, err
 						}
 
-						for email, recipient := range pkg.Addresses {
-							if recipient.Type != proton.InternalScheme {
-								continue
+						acc.updateIDs = append(acc.updateIDs, updateID)
+
+						for _, pkg := range packages {
+							bodyData, err := base64.StdEncoding.DecodeString(pkg.Body)
+							if err != nil {
+								return proton.Message{}, err
 							}
 
-							if err := b.withAccEmail(email, func(acc *account) error {
-								bodyKey, err := base64.StdEncoding.DecodeString(recipient.BodyKeyPacket)
-								if err != nil {
-									return err
+							for email, recipient := range pkg.Addresses {
+								if recipient.Type != proton.InternalScheme {
+									continue
 								}
 
-								armBody, err := crypto.NewPGPSplitMessage(bodyKey, bodyData).GetPGPMessage().GetArmored()
-								if err != nil {
-									return err
-								}
-
-								addrID, err := b.GetAddressID(email)
-								if err != nil {
-									return err
-								}
-
-								newMsg := newMessageFromSent(addrID, armBody, msg)
-								newMsg.flags |= proton.MessageFlagReceived
-								newMsg.addLabel(proton.InboxLabel, labels)
-								newMsg.unread = true
-								messages[newMsg.messageID] = newMsg
-
-								for _, attID := range msg.attIDs {
-									attKey, err := base64.StdEncoding.DecodeString(recipient.AttachmentKeyPackets[attID])
+								if err := b.withAccEmail(email, func(acc *account) error {
+									bodyKey, err := base64.StdEncoding.DecodeString(recipient.BodyKeyPacket)
 									if err != nil {
 										return err
 									}
 
-									att := newAttachment(
-										atts[attID].filename,
-										atts[attID].mimeType,
-										atts[attID].disposition,
-										atts[attID].contentID,
-										attKey,
-										atts[attID].attDataID,
-										atts[attID].armSig,
-									)
-									atts[att.attachID] = att
-									messages[newMsg.messageID].attIDs = append(messages[newMsg.messageID].attIDs, att.attachID)
+									armBody, err := crypto.NewPGPSplitMessage(bodyKey, bodyData).GetPGPMessage().GetArmored()
+									if err != nil {
+										return err
+									}
+
+									addrID, err := b.getAddressID(email)
+									if err != nil {
+										return err
+									}
+
+									newMsg := newMessageFromSent(addrID, armBody, msg)
+									newMsg.flags |= proton.MessageFlagReceived
+									newMsg.addLabel(proton.InboxLabel, labels)
+									newMsg.unread = true
+									messages[newMsg.messageID] = newMsg
+
+									for _, attID := range msg.attIDs {
+										attKey, err := base64.StdEncoding.DecodeString(recipient.AttachmentKeyPackets[attID])
+										if err != nil {
+											return err
+										}
+
+										att := newAttachment(
+											atts[attID].filename,
+											atts[attID].mimeType,
+											atts[attID].disposition,
+											atts[attID].contentID,
+											attKey,
+											atts[attID].attDataID,
+											atts[attID].armSig,
+										)
+										atts[att.attachID] = att
+										messages[newMsg.messageID].attIDs = append(messages[newMsg.messageID].attIDs, att.attachID)
+									}
+									// Sort Message attachments
+									messages[newMsg.messageID].attIDs = sortAttachment(atts, messages[newMsg.messageID].attIDs)
+									msg.attIDs = sortAttachment(atts, msg.attIDs)
+
+									// Send the update event
+									updateID, err := b.newUpdate(&messageCreated{messageID: newMsg.messageID})
+									if err != nil {
+										return err
+									}
+
+									acc.messageIDs = append(acc.messageIDs, newMsg.messageID)
+									acc.updateIDs = append(acc.updateIDs, updateID)
+
+									return nil
+								}); err != nil {
+									return proton.Message{}, err
 								}
-								// Sort Message attachments
-								messages[newMsg.messageID].attIDs = sortAttachment(atts, messages[newMsg.messageID].attIDs)
-								msg.attIDs = sortAttachment(atts, msg.attIDs)
-
-								// Send the update event
-								updateID, err := b.newUpdate(&messageCreated{messageID: newMsg.messageID})
-								if err != nil {
-									return err
-								}
-
-								acc.messageIDs = append(acc.messageIDs, newMsg.messageID)
-								acc.updateIDs = append(acc.updateIDs, updateID)
-
-								return nil
-							}); err != nil {
-								return proton.Message{}, err
 							}
 						}
-					}
 
-					return msg.toMessage(b.attData, atts), nil
+						return msg.toMessage(b.attData, atts), nil
+					})
 				})
 			})
 		})
@@ -895,53 +967,59 @@ func (b *Backend) CreateAttachment(
 		return proton.Attachment{}, errors.New("The 'inline' Disposition is only allowed with Content ID")
 	}
 
-	return withAcc(b, userID, func(acc *account) (proton.Attachment, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Attachment, error) {
-			return withAtts(b, func(atts map[string]*attachment) (proton.Attachment, error) {
-				att := newAttachment(
-					filename,
-					mimeType,
-					disposition,
-					contentID,
-					keyPackets,
-					b.createAttData(dataPacket),
-					armSig,
-				)
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Attachment, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Attachment, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Attachment, error) {
+				return withAtts(b, func(atts map[string]*attachment) (proton.Attachment, error) {
+					att := newAttachment(
+						filename,
+						mimeType,
+						disposition,
+						contentID,
+						keyPackets,
+						b.createAttData(dataPacket),
+						armSig,
+					)
 
-				atts[att.attachID] = att
+					atts[att.attachID] = att
 
-				// append attachment
-				messages[messageID].attIDs = append(messages[messageID].attIDs, att.attachID)
-				// sort the attachment list
-				messages[messageID].attIDs = sortAttachment(atts, messages[messageID].attIDs)
+					// append attachment
+					messages[messageID].attIDs = append(messages[messageID].attIDs, att.attachID)
+					// sort the attachment list
+					messages[messageID].attIDs = sortAttachment(atts, messages[messageID].attIDs)
 
-				updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
-				if err != nil {
-					return proton.Attachment{}, err
-				}
+					updateID, err := b.newUpdate(&messageUpdated{messageID: messageID})
+					if err != nil {
+						return proton.Attachment{}, err
+					}
 
-				acc.updateIDs = append(acc.updateIDs, updateID)
+					acc.updateIDs = append(acc.updateIDs, updateID)
 
-				return att.toAttachment(), nil
+					return att.toAttachment(), nil
+				})
 			})
 		})
 	})
 }
 
 func (b *Backend) GetAttachment(attachID string) ([]byte, error) {
-	return withAtts(b, func(atts map[string]*attachment) ([]byte, error) {
-		att, ok := atts[attachID]
-		if !ok {
-			return nil, fmt.Errorf("no such attachment: %s", attachID)
-		}
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]byte, error) {
+		return withAtts(b, func(atts map[string]*attachment) ([]byte, error) {
+			att, ok := atts[attachID]
+			if !ok {
+				return nil, fmt.Errorf("no such attachment: %s", attachID)
+			}
 
-		return b.attData[att.attDataID], nil
+			return b.attData[att.attDataID], nil
+		})
 	})
 }
 
 func (b *Backend) GetLatestEventID(userID string) (string, error) {
-	return withAcc(b, userID, func(acc *account) (string, error) {
-		return acc.updateIDs[len(acc.updateIDs)-1].String(), nil
+	return readBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return withAcc(b, userID, func(acc *account) (string, error) {
+			return acc.updateIDs[len(acc.updateIDs)-1].String(), nil
+		})
 	})
 }
 
@@ -962,25 +1040,27 @@ func (b *Backend) GetEvent(userID, rawEventID string) (event proton.Event, more 
 
 	more = false
 
-	event, err = withAcc(b, userID, func(acc *account) (proton.Event, error) {
-		return withMessages(b, func(messages map[string]*message) (proton.Event, error) {
-			return withLabels(b, func(labels map[string]*label) (proton.Event, error) {
-				return withAtts(b, func(attachments map[string]*attachment) (proton.Event, error) {
-					firstUpdate := xslices.Index(acc.updateIDs, eventID) + 1
-					lastUpdate := getLastUpdateIndex(len(acc.updateIDs), firstUpdate, b.maxUpdatesPerEvent)
+	event, err = readBackendRetErr(b, func(b *unsafeBackend) (proton.Event, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Event, error) {
+			return withMessages(b, func(messages map[string]*message) (proton.Event, error) {
+				return withLabels(b, func(labels map[string]*label) (proton.Event, error) {
+					return withAtts(b, func(attachments map[string]*attachment) (proton.Event, error) {
+						firstUpdate := xslices.Index(acc.updateIDs, eventID) + 1
+						lastUpdate := getLastUpdateIndex(len(acc.updateIDs), firstUpdate, b.maxUpdatesPerEvent)
 
-					updates, err := withUpdates(b, func(updates map[ID]update) ([]update, error) {
-						return merge(xslices.Map(acc.updateIDs[firstUpdate:lastUpdate], func(updateID ID) update {
-							return updates[updateID]
-						})), nil
+						updates, err := withUpdates(b, func(updates map[ID]update) ([]update, error) {
+							return merge(xslices.Map(acc.updateIDs[firstUpdate:lastUpdate], func(updateID ID) update {
+								return updates[updateID]
+							})), nil
+						})
+						if err != nil {
+							return proton.Event{}, fmt.Errorf("failed to merge updates: %w", err)
+						}
+
+						more = lastUpdate != len(acc.updateIDs)
+
+						return buildEvent(updates, acc.addresses, messages, labels, acc.updateIDs[lastUpdate-1].String(), b.attData, attachments, acc.toUser()), nil
 					})
-					if err != nil {
-						return proton.Event{}, fmt.Errorf("failed to merge updates: %w", err)
-					}
-
-					more = lastUpdate != len(acc.updateIDs)
-
-					return buildEvent(updates, acc.addresses, messages, labels, acc.updateIDs[lastUpdate-1].String(), b.attData, attachments, acc.toUser()), nil
 				})
 			})
 		})
@@ -994,31 +1074,33 @@ func (b *Backend) GetEvent(userID, rawEventID string) (event proton.Event, more 
 }
 
 func (b *Backend) GetPublicKeys(email string) ([]proton.PublicKey, error) {
-	return withAccEmail(b, email, func(acc *account) ([]proton.PublicKey, error) {
-		var keys []proton.PublicKey
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.PublicKey, error) {
+		return withAccEmail(b, email, func(acc *account) ([]proton.PublicKey, error) {
+			var keys []proton.PublicKey
 
-		for _, addr := range acc.addresses {
-			if addr.email == email {
-				for _, key := range addr.keys {
-					pubKey, err := key.getPubKey()
-					if err != nil {
-						return nil, err
+			for _, addr := range acc.addresses {
+				if addr.email == email {
+					for _, key := range addr.keys {
+						pubKey, err := key.getPubKey()
+						if err != nil {
+							return nil, err
+						}
+
+						armKey, err := pubKey.GetArmoredPublicKey()
+						if err != nil {
+							return nil, err
+						}
+
+						keys = append(keys, proton.PublicKey{
+							Flags:     proton.KeyStateTrusted | proton.KeyStateActive,
+							PublicKey: armKey,
+						})
 					}
-
-					armKey, err := pubKey.GetArmoredPublicKey()
-					if err != nil {
-						return nil, err
-					}
-
-					keys = append(keys, proton.PublicKey{
-						Flags:     proton.KeyStateTrusted | proton.KeyStateActive,
-						PublicKey: armKey,
-					})
 				}
 			}
-		}
 
-		return keys, nil
+			return keys, nil
+		})
 	})
 }
 
@@ -1035,108 +1117,120 @@ func getLabelIDsToDelete(labelID string, labels map[string]*label) []string {
 }
 
 func (b *Backend) AddAddressCreatedUpdate(userID, addrID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		updateID, err := b.newUpdate(&addressCreated{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) AddLabelCreatedUpdate(userID, labelID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		updateID, err := b.newUpdate(&labelCreated{labelID: labelID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) AddMessageCreatedUpdate(userID, messageID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		updateID, err := b.newUpdate(&messageCreated{messageID: messageID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
-	})
-}
-
-func (b *Backend) GetMessageGroupCount(userID string) ([]proton.MessageGroupCount, error) {
-	var result []proton.MessageGroupCount
-	err := b.withAcc(userID, func(acc *account) error {
-		return b.withMessages(func(m map[string]*message) error {
-			type stats struct {
-				total  int
-				unread int
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			updateID, err := b.newUpdate(&addressCreated{addressID: addrID})
+			if err != nil {
+				return err
 			}
 
-			labelStats := make(map[string]stats)
-
-			for _, msg := range m {
-				for _, lbl := range msg.getLabelIDs() {
-					v, ok := labelStats[lbl]
-					if !ok {
-						v = stats{}
-					}
-					v.total++
-					if msg.unread {
-						v.unread++
-					}
-
-					labelStats[lbl] = v
-				}
-			}
-
-			result = make([]proton.MessageGroupCount, 0, len(labelStats))
-
-			for lbl, stats := range labelStats {
-				result = append(result, proton.MessageGroupCount{
-					LabelID: lbl,
-					Total:   stats.total,
-					Unread:  stats.unread,
-				})
-			}
+			acc.updateIDs = append(acc.updateIDs, updateID)
 
 			return nil
 		})
 	})
+}
 
-	return result, err
+func (b *Backend) AddLabelCreatedUpdate(userID, labelID string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			updateID, err := b.newUpdate(&labelCreated{labelID: labelID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
+		})
+	})
+}
+
+func (b *Backend) AddMessageCreatedUpdate(userID, messageID string) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			updateID, err := b.newUpdate(&messageCreated{messageID: messageID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
+		})
+	})
+}
+
+func (b *Backend) GetMessageGroupCount(userID string) ([]proton.MessageGroupCount, error) {
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.MessageGroupCount, error) {
+		var result []proton.MessageGroupCount
+		err := b.withAcc(userID, func(acc *account) error {
+			return b.withMessages(func(m map[string]*message) error {
+				type stats struct {
+					total  int
+					unread int
+				}
+
+				labelStats := make(map[string]stats)
+
+				for _, msg := range m {
+					for _, lbl := range msg.getLabelIDs() {
+						v, ok := labelStats[lbl]
+						if !ok {
+							v = stats{}
+						}
+						v.total++
+						if msg.unread {
+							v.unread++
+						}
+
+						labelStats[lbl] = v
+					}
+				}
+
+				result = make([]proton.MessageGroupCount, 0, len(labelStats))
+
+				for lbl, stats := range labelStats {
+					result = append(result, proton.MessageGroupCount{
+						LabelID: lbl,
+						Total:   stats.total,
+						Unread:  stats.unread,
+					})
+				}
+
+				return nil
+			})
+		})
+
+		return result, err
+	})
 }
 
 func (b *Backend) GetUserContact(userID, contactID string) (proton.Contact, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
-		contact, ok := acc.contacts[contactID]
-		if ok {
-			return *contact, nil
-		}
-		return proton.Contact{}, errors.New("No such contact with ID" + contactID)
+	return readBackendRetErr(b, func(b *unsafeBackend) (proton.Contact, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
+			contact, ok := acc.contacts[contactID]
+			if ok {
+				return *contact, nil
+			}
+			return proton.Contact{}, errors.New("No such contact with ID" + contactID)
+		})
 	})
 }
 
 func (b *Backend) GetUserContacts(userID string, page int, pageSize int) (int, []proton.Contact, error) {
 	var total int
-	contacts, err := withAcc(b, userID, func(acc *account) ([]proton.Contact, error) {
-		total = len(acc.contacts)
-		values := maps.Values(acc.contacts)
-		slices.SortFunc(values, func(i, j *proton.Contact) bool {
-			return strings.Compare(i.ID, j.ID) < 0
+	contacts, err := readBackendRetErr(b, func(b *unsafeBackend) ([]proton.Contact, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.Contact, error) {
+			total = len(acc.contacts)
+			values := maps.Values(acc.contacts)
+			slices.SortFunc(values, func(i, j *proton.Contact) bool {
+				return strings.Compare(i.ID, j.ID) < 0
+			})
+			return xslices.Map(xslices.Chunk(values, pageSize)[page], func(c *proton.Contact) proton.Contact {
+				return *c
+			}), nil
 		})
-		return xslices.Map(xslices.Chunk(values, pageSize)[page], func(c *proton.Contact) proton.Contact {
-			return *c
-		}), nil
 	})
 
 	return total, contacts, err
@@ -1145,50 +1239,58 @@ func (b *Backend) GetUserContacts(userID string, page int, pageSize int) (int, [
 func (b *Backend) GetUserContactEmails(userID, email string, page int, pageSize int) (int, []proton.ContactEmail, error) {
 	var total int
 
-	emails, err := withAcc(b, userID, func(acc *account) ([]proton.ContactEmail, error) {
-		var contacts []proton.ContactEmail
-		for _, contact := range acc.contacts {
-			for _, contactEmail := range contact.ContactEmails {
-				if email == "" || contactEmail.Email == email {
-					contacts = append(contacts, contactEmail)
+	emails, err := readBackendRetErr(b, func(b *unsafeBackend) ([]proton.ContactEmail, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.ContactEmail, error) {
+			var contacts []proton.ContactEmail
+			for _, contact := range acc.contacts {
+				for _, contactEmail := range contact.ContactEmails {
+					if email == "" || contactEmail.Email == email {
+						contacts = append(contacts, contactEmail)
+					}
 				}
 			}
-		}
 
-		total = len(contacts)
+			total = len(contacts)
 
-		if total < pageSize {
-			return contacts, nil
-		}
+			if total < pageSize {
+				return contacts, nil
+			}
 
-		slices.SortFunc(contacts, func(a, b proton.ContactEmail) bool {
-			return strings.Compare(a.ID, b.ID) < 0
+			slices.SortFunc(contacts, func(a, b proton.ContactEmail) bool {
+				return strings.Compare(a.ID, b.ID) < 0
+			})
+
+			return xslices.Chunk(contacts, pageSize)[page], nil
 		})
-
-		return xslices.Chunk(contacts, pageSize)[page], nil
 	})
 
 	return total, emails, err
 }
 
 func (b *Backend) AddUserContact(userID string, contact proton.Contact) (proton.Contact, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
-		acc.contacts[contact.ID] = &contact
-		return *acc.contacts[contact.ID], nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Contact, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
+			acc.contacts[contact.ID] = &contact
+			return *acc.contacts[contact.ID], nil
+		})
 	})
 }
 
 func (b *Backend) UpdateUserContact(userID, contactID string, cards proton.Cards) (proton.Contact, error) {
-	return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
-		acc.contacts[contactID].Cards = cards
-		return *acc.contacts[contactID], nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Contact, error) {
+		return withAcc(b, userID, func(acc *account) (proton.Contact, error) {
+			acc.contacts[contactID].Cards = cards
+			return *acc.contacts[contactID], nil
+		})
 	})
 }
 
 func (b *Backend) GenerateContactID(userID string) (string, error) {
-	return withAcc(b, userID, func(acc *account) (string, error) {
-		acc.contactCounter++
-		return strconv.Itoa(acc.contactCounter), nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return withAcc(b, userID, func(acc *account) (string, error) {
+			acc.contactCounter++
+			return strconv.Itoa(acc.contactCounter), nil
+		})
 	})
 }
 

--- a/server/backend/api_auth.go
+++ b/server/backend/api_auth.go
@@ -10,117 +10,120 @@ import (
 )
 
 func (b *Backend) NewAuthInfo(username string) (proton.AuthInfo, error) {
-	return withAccName(b, username, func(acc *account) (proton.AuthInfo, error) {
-		server, err := srp.NewServerFromSigned(modulus, acc.verifier, 2048)
-		if err != nil {
-			return proton.AuthInfo{}, nil
-		}
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.AuthInfo, error) {
+		return withAccName(b, username, func(acc *account) (proton.AuthInfo, error) {
+			server, err := srp.NewServerFromSigned(modulus, acc.verifier, 2048)
+			if err != nil {
+				return proton.AuthInfo{}, nil
+			}
 
-		challenge, err := server.GenerateChallenge()
-		if err != nil {
-			return proton.AuthInfo{}, nil
-		}
+			challenge, err := server.GenerateChallenge()
+			if err != nil {
+				return proton.AuthInfo{}, nil
+			}
 
-		session := uuid.NewString()
+			session := uuid.NewString()
 
-		b.srpLock.Lock()
-		defer b.srpLock.Unlock()
+			b.srp[session] = server
 
-		b.srp[session] = server
-
-		return proton.AuthInfo{
-			Version:         4,
-			Modulus:         modulus,
-			ServerEphemeral: base64.StdEncoding.EncodeToString(challenge),
-			Salt:            base64.StdEncoding.EncodeToString(acc.salt),
-			SRPSession:      session,
-		}, nil
+			return proton.AuthInfo{
+				Version:         4,
+				Modulus:         modulus,
+				ServerEphemeral: base64.StdEncoding.EncodeToString(challenge),
+				Salt:            base64.StdEncoding.EncodeToString(acc.salt),
+				SRPSession:      session,
+			}, nil
+		})
 	})
 }
 
 func (b *Backend) NewAuth(username string, ephemeral, proof []byte, session string) (proton.Auth, error) {
-	return withAccName(b, username, func(acc *account) (proton.Auth, error) {
-		b.srpLock.Lock()
-		defer b.srpLock.Unlock()
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Auth, error) {
+		return withAccName(b, username, func(acc *account) (proton.Auth, error) {
+			server, ok := b.srp[session]
+			if !ok {
+				return proton.Auth{}, fmt.Errorf("invalid session")
+			}
 
-		server, ok := b.srp[session]
-		if !ok {
-			return proton.Auth{}, fmt.Errorf("invalid session")
-		}
+			delete(b.srp, session)
 
-		delete(b.srp, session)
+			serverProof, err := server.VerifyProofs(ephemeral, proof)
+			if !ok {
+				return proton.Auth{}, fmt.Errorf("invalid proof: %w", err)
+			}
 
-		serverProof, err := server.VerifyProofs(ephemeral, proof)
-		if !ok {
-			return proton.Auth{}, fmt.Errorf("invalid proof: %w", err)
-		}
+			authUID, auth := uuid.NewString(), newAuth(b.authLife)
 
-		authUID, auth := uuid.NewString(), newAuth(b.authLife)
+			acc.authLock.Lock()
+			defer acc.authLock.Unlock()
 
-		acc.authLock.Lock()
-		defer acc.authLock.Unlock()
+			acc.auth[authUID] = auth
 
-		acc.auth[authUID] = auth
-
-		return auth.toAuth(acc.userID, authUID, serverProof), nil
+			return auth.toAuth(acc.userID, authUID, serverProof), nil
+		})
 	})
 }
 
 func (b *Backend) NewAuthRef(authUID, authRef string) (proton.Auth, error) {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
+	return writeBackendRetErr(b, func(b *unsafeBackend) (proton.Auth, error) {
+		for _, acc := range b.accounts {
+			acc.authLock.Lock()
+			defer acc.authLock.Unlock()
 
-	for _, acc := range b.accounts {
-		acc.authLock.Lock()
-		defer acc.authLock.Unlock()
+			auth, ok := acc.auth[authUID]
+			if !ok {
+				continue
+			}
 
-		auth, ok := acc.auth[authUID]
-		if !ok {
-			continue
+			if auth.ref != authRef {
+				return proton.Auth{}, fmt.Errorf("invalid auth ref")
+			}
+
+			newAuth := newAuth(b.authLife)
+
+			acc.auth[authUID] = newAuth
+
+			return newAuth.toAuth(acc.userID, authUID, nil), nil
 		}
 
-		if auth.ref != authRef {
-			return proton.Auth{}, fmt.Errorf("invalid auth ref")
-		}
-
-		newAuth := newAuth(b.authLife)
-
-		acc.auth[authUID] = newAuth
-
-		return newAuth.toAuth(acc.userID, authUID, nil), nil
-	}
-
-	return proton.Auth{}, fmt.Errorf("invalid auth")
+		return proton.Auth{}, fmt.Errorf("invalid auth")
+	})
 }
 
 func (b *Backend) VerifyAuth(authUID, authAcc string) (string, error) {
-	return withAccAuth(b, authUID, authAcc, func(acc *account) (string, error) {
-		return acc.userID, nil
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return withAccAuth(b, authUID, authAcc, func(acc *account) (string, error) {
+			return acc.userID, nil
+		})
 	})
 }
 
 func (b *Backend) GetSessions(userID string) ([]proton.AuthSession, error) {
-	return withAcc(b, userID, func(acc *account) ([]proton.AuthSession, error) {
-		acc.authLock.RLock()
-		defer acc.authLock.RUnlock()
+	return readBackendRetErr(b, func(b *unsafeBackend) ([]proton.AuthSession, error) {
+		return withAcc(b, userID, func(acc *account) ([]proton.AuthSession, error) {
+			acc.authLock.RLock()
+			defer acc.authLock.RUnlock()
 
-		var sessions []proton.AuthSession
+			var sessions []proton.AuthSession
 
-		for authUID, auth := range acc.auth {
-			sessions = append(sessions, auth.toAuthSession(authUID))
-		}
+			for authUID, auth := range acc.auth {
+				sessions = append(sessions, auth.toAuthSession(authUID))
+			}
 
-		return sessions, nil
+			return sessions, nil
+		})
 	})
 }
 
 func (b *Backend) DeleteSession(userID, authUID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		acc.authLock.Lock()
-		defer acc.authLock.Unlock()
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			acc.authLock.Lock()
+			defer acc.authLock.Unlock()
 
-		delete(acc.auth, authUID)
+			delete(acc.auth, authUID)
 
-		return nil
+			return nil
+		})
 	})
 }

--- a/server/backend/attachment.go
+++ b/server/backend/attachment.go
@@ -8,11 +8,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (b *Backend) createAttData(dataPacket []byte) string {
+func (b *unsafeBackend) createAttData(dataPacket []byte) string {
 	attDataID := uuid.NewString()
-
-	b.attDataLock.Lock()
-	defer b.attDataLock.Unlock()
 
 	b.attData[attDataID] = dataPacket
 

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -19,201 +19,243 @@ import (
 type Backend struct {
 	domain string
 
+	lock        sync.RWMutex
+	safeBackend *unsafeBackend
+}
+
+// unsafeBackend does not guarantee any thread safety. Methods exposed by Backend should ensure they acquire
+// either a Read Lock or Write lock depending on the required changes.
+type unsafeBackend struct {
 	accounts map[string]*account
-	accLock  sync.RWMutex
 
 	attachments map[string]*attachment
-	attLock     sync.Mutex
 
-	attData     map[string][]byte
-	attDataLock sync.Mutex
+	attData map[string][]byte
 
 	messages map[string]*message
-	msgLock  sync.Mutex
 
-	labels  map[string]*label
-	lblLock sync.Mutex
+	labels map[string]*label
 
 	updates            map[ID]update
-	updatesLock        sync.RWMutex
 	maxUpdatesPerEvent int
 
-	srp     map[string]*srp.Server
-	srpLock sync.Mutex
+	srp map[string]*srp.Server
 
 	authLife    time.Duration
 	enableDedup bool
 
-	csTicket     []string
-	csTicketLock sync.Mutex
+	csTicket []string
+}
+
+func readBackendRet[T any](b *Backend, f func(b *unsafeBackend) T) T {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	return f(b.safeBackend)
+}
+
+func readBackendRetErr[T any](b *Backend, f func(b *unsafeBackend) (T, error)) (T, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	return f(b.safeBackend)
+}
+
+func writeBackend(b *Backend, f func(b *unsafeBackend)) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	f(b.safeBackend)
+}
+
+func writeBackendRet[T any](b *Backend, f func(b *unsafeBackend) T) T {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return f(b.safeBackend)
+}
+
+func writeBackendRetErr[T any](b *Backend, f func(b *unsafeBackend) (T, error)) (T, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return f(b.safeBackend)
 }
 
 func New(authLife time.Duration, domain string, enableDedup bool) *Backend {
 	return &Backend{
-		domain:             domain,
-		accounts:           make(map[string]*account),
-		attachments:        make(map[string]*attachment),
-		attData:            make(map[string][]byte),
-		messages:           make(map[string]*message),
-		labels:             make(map[string]*label),
-		updates:            make(map[ID]update),
-		maxUpdatesPerEvent: 0,
-		srp:                make(map[string]*srp.Server),
-		authLife:           authLife,
-		enableDedup:        enableDedup,
+		domain: domain,
+		safeBackend: &unsafeBackend{
+			accounts:           make(map[string]*account),
+			attachments:        make(map[string]*attachment),
+			attData:            make(map[string][]byte),
+			messages:           make(map[string]*message),
+			labels:             make(map[string]*label),
+			updates:            make(map[ID]update),
+			maxUpdatesPerEvent: 0,
+			srp:                make(map[string]*srp.Server),
+			authLife:           authLife,
+			enableDedup:        enableDedup,
+		},
 	}
 }
 
 func (b *Backend) SetAuthLife(authLife time.Duration) {
-	b.authLife = authLife
+	writeBackend(b, func(b *unsafeBackend) {
+		b.authLife = authLife
+	})
 }
 
 func (b *Backend) SetMaxUpdatesPerEvent(max int) {
-	b.maxUpdatesPerEvent = max
+	writeBackend(b, func(b *unsafeBackend) {
+		b.maxUpdatesPerEvent = max
+	})
 }
 
 func (b *Backend) CreateUser(username string, password []byte) (string, error) {
-	b.accLock.Lock()
-	defer b.accLock.Unlock()
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		salt, err := crypto.RandomToken(16)
+		if err != nil {
+			return "", err
+		}
 
-	salt, err := crypto.RandomToken(16)
-	if err != nil {
-		return "", err
-	}
+		passphrase, err := hashPassword(password, salt)
+		if err != nil {
+			return "", err
+		}
 
-	passphrase, err := hashPassword(password, salt)
-	if err != nil {
-		return "", err
-	}
+		srpAuth, err := srp.NewAuthForVerifier(password, modulus, salt)
+		if err != nil {
+			return "", err
+		}
 
-	srpAuth, err := srp.NewAuthForVerifier(password, modulus, salt)
-	if err != nil {
-		return "", err
-	}
+		verifier, err := srpAuth.GenerateVerifier(2048)
+		if err != nil {
+			return "", err
+		}
 
-	verifier, err := srpAuth.GenerateVerifier(2048)
-	if err != nil {
-		return "", err
-	}
+		armKey, err := GenerateKey(username, username, passphrase, "rsa", 2048)
+		if err != nil {
+			return "", err
+		}
 
-	armKey, err := GenerateKey(username, username, passphrase, "rsa", 2048)
-	if err != nil {
-		return "", err
-	}
+		userID := uuid.NewString()
 
-	userID := uuid.NewString()
+		b.accounts[userID] = newAccount(userID, username, armKey, salt, verifier)
 
-	b.accounts[userID] = newAccount(userID, username, armKey, salt, verifier)
-
-	return userID, nil
+		return userID, nil
+	})
 }
 
 func (b *Backend) RemoveUser(userID string) error {
-	b.accLock.Lock()
-	defer b.accLock.Unlock()
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		user, ok := b.accounts[userID]
+		if !ok {
+			return fmt.Errorf("user %s does not exist", userID)
+		}
 
-	user, ok := b.accounts[userID]
-	if !ok {
-		return fmt.Errorf("user %s does not exist", userID)
-	}
+		for _, labelID := range user.labelIDs {
+			delete(b.labels, labelID)
+		}
 
-	for _, labelID := range user.labelIDs {
-		delete(b.labels, labelID)
-	}
+		for _, messageID := range user.messageIDs {
+			for _, attID := range b.messages[messageID].attIDs {
+				if xslices.CountFunc(maps.Values(b.attachments), func(att *attachment) bool {
+					return att.attDataID == b.attachments[attID].attDataID
+				}) == 1 {
+					delete(b.attData, b.attachments[attID].attDataID)
+				}
 
-	for _, messageID := range user.messageIDs {
-		for _, attID := range b.messages[messageID].attIDs {
-			if xslices.CountFunc(maps.Values(b.attachments), func(att *attachment) bool {
-				return att.attDataID == b.attachments[attID].attDataID
-			}) == 1 {
-				delete(b.attData, b.attachments[attID].attDataID)
+				delete(b.attachments, attID)
 			}
 
-			delete(b.attachments, attID)
+			delete(b.messages, messageID)
 		}
 
-		delete(b.messages, messageID)
-	}
-
-	delete(b.accounts, userID)
-
-	return nil
-}
-
-func (b *Backend) RefreshUser(userID string, refresh proton.RefreshFlag) error {
-	return b.withAcc(userID, func(acc *account) error {
-		updateID, err := b.newUpdate(&userRefreshed{refresh: refresh})
-		if err != nil {
-			return err
-		}
-
-		if refresh == proton.RefreshAll {
-			acc.updateIDs = []ID{updateID}
-		} else {
-			acc.updateIDs = append(acc.updateIDs, updateID)
-		}
+		delete(b.accounts, userID)
 
 		return nil
 	})
 }
 
+func (b *Backend) RefreshUser(userID string, refresh proton.RefreshFlag) error {
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			updateID, err := b.newUpdate(&userRefreshed{refresh: refresh})
+			if err != nil {
+				return err
+			}
+
+			if refresh == proton.RefreshAll {
+				acc.updateIDs = []ID{updateID}
+			} else {
+				acc.updateIDs = append(acc.updateIDs, updateID)
+			}
+
+			return nil
+		})
+	})
+}
+
 func (b *Backend) CreateUserKey(userID string, password []byte) error {
-	b.accLock.Lock()
-	defer b.accLock.Unlock()
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		user, ok := b.accounts[userID]
+		if !ok {
+			return fmt.Errorf("user %s does not exist", userID)
+		}
 
-	user, ok := b.accounts[userID]
-	if !ok {
-		return fmt.Errorf("user %s does not exist", userID)
-	}
+		salt, err := crypto.RandomToken(16)
+		if err != nil {
+			return err
+		}
 
-	salt, err := crypto.RandomToken(16)
-	if err != nil {
-		return err
-	}
+		passphrase, err := hashPassword(password, salt)
+		if err != nil {
+			return err
+		}
 
-	passphrase, err := hashPassword(password, salt)
-	if err != nil {
-		return err
-	}
+		armKey, err := GenerateKey(user.username, user.username, passphrase, "rsa", 2048)
+		if err != nil {
+			return err
+		}
 
-	armKey, err := GenerateKey(user.username, user.username, passphrase, "rsa", 2048)
-	if err != nil {
-		return err
-	}
+		user.keys = append(user.keys, key{keyID: uuid.NewString(), key: armKey})
 
-	user.keys = append(user.keys, key{keyID: uuid.NewString(), key: armKey})
-
-	return nil
+		return nil
+	})
 }
 
 func (b *Backend) RemoveUserKey(userID, keyID string) error {
-	b.accLock.Lock()
-	defer b.accLock.Unlock()
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		user, ok := b.accounts[userID]
+		if !ok {
+			return fmt.Errorf("user %s does not exist", userID)
+		}
 
-	user, ok := b.accounts[userID]
-	if !ok {
-		return fmt.Errorf("user %s does not exist", userID)
-	}
+		idx := xslices.IndexFunc(user.keys, func(key key) bool {
+			return key.keyID == keyID
+		})
 
-	idx := xslices.IndexFunc(user.keys, func(key key) bool {
-		return key.keyID == keyID
+		if idx == -1 {
+			return fmt.Errorf("key %s does not exist", keyID)
+		}
+
+		user.keys = append(user.keys[:idx], user.keys[idx+1:]...)
+
+		return nil
 	})
-
-	if idx == -1 {
-		return fmt.Errorf("key %s does not exist", keyID)
-	}
-
-	user.keys = append(user.keys[:idx], user.keys[idx+1:]...)
-
-	return nil
 }
 
 func (b *Backend) CreateAddress(userID, email string, password []byte, withKey bool, status proton.AddressStatus, addrType proton.AddressType) (string, error) {
-	return b.createAddress(userID, email, password, withKey, status, addrType, false, true)
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return b.createAddress(userID, email, password, withKey, status, addrType, false, true)
+	})
 }
 
 func (b *Backend) CreateAddressAsUpdate(userID, email string, password []byte, withKey bool, status proton.AddressStatus, addrType proton.AddressType) (string, error) {
-	return b.createAddress(userID, email, password, withKey, status, addrType, true, true)
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return b.createAddress(userID, email, password, withKey, status, addrType, true, true)
+	})
 }
 
 func (b *Backend) CreateAddressWithSendDisabled(
@@ -223,10 +265,12 @@ func (b *Backend) CreateAddressWithSendDisabled(
 	status proton.AddressStatus,
 	addrType proton.AddressType,
 ) (string, error) {
-	return b.createAddress(userID, email, password, withKey, status, addrType, false, false)
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return b.createAddress(userID, email, password, withKey, status, addrType, false, false)
+	})
 }
 
-func (b *Backend) createAddress(
+func (b *unsafeBackend) createAddress(
 	userID, email string,
 	password []byte,
 	withKey bool,
@@ -304,125 +348,137 @@ func (b *Backend) createAddress(
 }
 
 func (b *Backend) ChangeAddressType(userID, addrID string, addrType proton.AddressType) error {
-	return b.withAcc(userID, func(acc *account) error {
-		for _, addr := range acc.addresses {
-			if addr.addrID == addrID {
-				addr.addrType = addrType
-				return nil
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			for _, addr := range acc.addresses {
+				if addr.addrID == addrID {
+					addr.addrType = addrType
+					return nil
+				}
 			}
-		}
-		return fmt.Errorf("no addrID matching %s for user %s", addrID, userID)
+			return fmt.Errorf("no addrID matching %s for user %s", addrID, userID)
+		})
 	})
 }
 
 func (b *Backend) ChangeAddressAllowSend(userID, addrId string, allowSend bool) error {
-	return b.withAcc(userID, func(acc *account) error {
-		for _, addr := range acc.addresses {
-			if addr.addrID == addrId {
-				addr.allowSend = allowSend
-				return nil
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			for _, addr := range acc.addresses {
+				if addr.addrID == addrId {
+					addr.allowSend = allowSend
+					return nil
+				}
 			}
-		}
-		return fmt.Errorf("no addrID matching %s for user %s", addrId, userID)
+			return fmt.Errorf("no addrID matching %s for user %s", addrId, userID)
+		})
 	})
 }
 
 func (b *Backend) ChangeAddressDisplayName(userID, addrID, displayName string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		for _, addr := range acc.addresses {
-			if addr.addrID == addrID {
-				addr.displayName = displayName
-				return nil
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			for _, addr := range acc.addresses {
+				if addr.addrID == addrID {
+					addr.displayName = displayName
+					return nil
+				}
 			}
-		}
-		return fmt.Errorf("no addrID matching %s for user %s", addrID, userID)
+			return fmt.Errorf("no addrID matching %s for user %s", addrID, userID)
+		})
 	})
 }
 
 func (b *Backend) CreateAddressKey(userID, addrID string, password []byte) error {
-	return b.withAcc(userID, func(acc *account) error {
-		token, err := crypto.RandomToken(32)
-		if err != nil {
-			return err
-		}
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			token, err := crypto.RandomToken(32)
+			if err != nil {
+				return err
+			}
 
-		armKey, err := GenerateKey(acc.username, acc.addresses[addrID].email, token, "rsa", 2048)
-		if err != nil {
-			return err
-		}
+			armKey, err := GenerateKey(acc.username, acc.addresses[addrID].email, token, "rsa", 2048)
+			if err != nil {
+				return err
+			}
 
-		passphrase, err := hashPassword([]byte(password), acc.salt)
-		if err != nil {
-			return err
-		}
+			passphrase, err := hashPassword([]byte(password), acc.salt)
+			if err != nil {
+				return err
+			}
 
-		userKR, err := acc.keys[0].unlock(passphrase)
-		if err != nil {
-			return err
-		}
+			userKR, err := acc.keys[0].unlock(passphrase)
+			if err != nil {
+				return err
+			}
 
-		encToken, sigToken, err := encryptWithSignature(userKR, token)
-		if err != nil {
-			return err
-		}
+			encToken, sigToken, err := encryptWithSignature(userKR, token)
+			if err != nil {
+				return err
+			}
 
-		acc.addresses[addrID].keys = append(acc.addresses[addrID].keys, key{
-			keyID: uuid.NewString(),
-			key:   armKey,
-			tok:   encToken,
-			sig:   sigToken,
+			acc.addresses[addrID].keys = append(acc.addresses[addrID].keys, key{
+				keyID: uuid.NewString(),
+				key:   armKey,
+				tok:   encToken,
+				sig:   sigToken,
+			})
+
+			updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
 		})
-
-		updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
 	})
 }
 
 func (b *Backend) RemoveAddress(userID, addrID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		if _, ok := acc.addresses[addrID]; !ok {
-			return fmt.Errorf("address %s not found", addrID)
-		}
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			if _, ok := acc.addresses[addrID]; !ok {
+				return fmt.Errorf("address %s not found", addrID)
+			}
 
-		delete(acc.addresses, addrID)
+			delete(acc.addresses, addrID)
 
-		updateID, err := b.newUpdate(&addressDeleted{addressID: addrID})
-		if err != nil {
-			return err
-		}
+			updateID, err := b.newUpdate(&addressDeleted{addressID: addrID})
+			if err != nil {
+				return err
+			}
 
-		acc.updateIDs = append(acc.updateIDs, updateID)
+			acc.updateIDs = append(acc.updateIDs, updateID)
 
-		return nil
+			return nil
+		})
 	})
 }
 
 func (b *Backend) RemoveAddressKey(userID, addrID, keyID string) error {
-	return b.withAcc(userID, func(acc *account) error {
-		idx := xslices.IndexFunc(acc.addresses[addrID].keys, func(key key) bool {
-			return key.keyID == keyID
+	return writeBackendRet(b, func(b *unsafeBackend) error {
+		return b.withAcc(userID, func(acc *account) error {
+			idx := xslices.IndexFunc(acc.addresses[addrID].keys, func(key key) bool {
+				return key.keyID == keyID
+			})
+
+			if idx < 0 {
+				return fmt.Errorf("key %s not found", keyID)
+			}
+
+			acc.addresses[addrID].keys = append(acc.addresses[addrID].keys[:idx], acc.addresses[addrID].keys[idx+1:]...)
+
+			updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
+			if err != nil {
+				return err
+			}
+
+			acc.updateIDs = append(acc.updateIDs, updateID)
+
+			return nil
 		})
-
-		if idx < 0 {
-			return fmt.Errorf("key %s not found", keyID)
-		}
-
-		acc.addresses[addrID].keys = append(acc.addresses[addrID].keys[:idx], acc.addresses[addrID].keys[idx+1:]...)
-
-		updateID, err := b.newUpdate(&addressUpdated{addressID: addrID})
-		if err != nil {
-			return err
-		}
-
-		acc.updateIDs = append(acc.updateIDs, updateID)
-
-		return nil
 	})
 }
 
@@ -442,91 +498,92 @@ func (b *Backend) CreateMessage(
 	date time.Time,
 	unread, starred bool,
 ) (string, error) {
-	return withAcc(b, userID, func(acc *account) (string, error) {
-		return withMessages(b, func(messages map[string]*message) (string, error) {
-			msg := newMessage(addrID, subject, sender, toList, ccList, bccList, replytos, armBody, mimeType, "", date)
+	return writeBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return withAcc(b, userID, func(acc *account) (string, error) {
+			return withMessages(b, func(messages map[string]*message) (string, error) {
+				msg := newMessage(addrID, subject, sender, toList, ccList, bccList, replytos, armBody, mimeType, "", date)
 
-			msg.flags |= flags
-			msg.unread = unread
-			msg.starred = starred
+				msg.flags |= flags
+				msg.unread = unread
+				msg.starred = starred
 
-			addrListEqual := func(l1 []*mail.Address, l2 []*mail.Address) bool {
-				s1 := xslices.Map(l1, func(addr *mail.Address) string {
-					return addr.Address
-				})
-				s2 := xslices.Map(l2, func(addr *mail.Address) string {
-					return addr.Address
-				})
+				addrListEqual := func(l1 []*mail.Address, l2 []*mail.Address) bool {
+					s1 := xslices.Map(l1, func(addr *mail.Address) string {
+						return addr.Address
+					})
+					s2 := xslices.Map(l2, func(addr *mail.Address) string {
+						return addr.Address
+					})
 
-				return slices.Equal(s1, s2)
-			}
-
-			var foundDuplicate bool
-
-			if b.enableDedup {
-				for _, m := range messages {
-					if m.addrID != msg.addrID {
-						continue
-					}
-
-					toEqual := addrListEqual(m.toList, msg.toList)
-					bccEqual := addrListEqual(m.bccList, msg.bccList)
-					ccEqual := addrListEqual(m.ccList, msg.ccList)
-
-					if m.sender.Address == msg.sender.Address &&
-						toEqual &&
-						bccEqual &&
-						ccEqual &&
-						m.subject == msg.subject {
-						msg.messageID = m.messageID
-						foundDuplicate = true
-						break
-					}
-				}
-			}
-
-			if !foundDuplicate {
-				messages[msg.messageID] = msg
-
-				updateID, err := b.newUpdate(&messageCreated{messageID: msg.messageID})
-				if err != nil {
-					return "", err
+					return slices.Equal(s1, s2)
 				}
 
-				acc.messageIDs = append(acc.messageIDs, msg.messageID)
-				acc.updateIDs = append(acc.updateIDs, updateID)
-			}
+				var foundDuplicate bool
 
-			return msg.messageID, nil
+				if b.enableDedup {
+					for _, m := range messages {
+						if m.addrID != msg.addrID {
+							continue
+						}
+
+						toEqual := addrListEqual(m.toList, msg.toList)
+						bccEqual := addrListEqual(m.bccList, msg.bccList)
+						ccEqual := addrListEqual(m.ccList, msg.ccList)
+
+						if m.sender.Address == msg.sender.Address &&
+							toEqual &&
+							bccEqual &&
+							ccEqual &&
+							m.subject == msg.subject {
+							msg.messageID = m.messageID
+							foundDuplicate = true
+							break
+						}
+					}
+				}
+
+				if !foundDuplicate {
+					messages[msg.messageID] = msg
+
+					updateID, err := b.newUpdate(&messageCreated{messageID: msg.messageID})
+					if err != nil {
+						return "", err
+					}
+
+					acc.messageIDs = append(acc.messageIDs, msg.messageID)
+					acc.updateIDs = append(acc.updateIDs, updateID)
+				}
+
+				return msg.messageID, nil
+			})
 		})
 	})
 }
 
 func (b *Backend) Encrypt(userID, addrID, decBody string) (string, error) {
-	return withAcc(b, userID, func(acc *account) (string, error) {
-		pubKey, err := acc.addresses[addrID].keys[0].getPubKey()
-		if err != nil {
-			return "", err
-		}
+	return readBackendRetErr(b, func(b *unsafeBackend) (string, error) {
+		return withAcc(b, userID, func(acc *account) (string, error) {
+			pubKey, err := acc.addresses[addrID].keys[0].getPubKey()
+			if err != nil {
+				return "", err
+			}
 
-		kr, err := crypto.NewKeyRing(pubKey)
-		if err != nil {
-			return "", err
-		}
+			kr, err := crypto.NewKeyRing(pubKey)
+			if err != nil {
+				return "", err
+			}
 
-		enc, err := kr.Encrypt(crypto.NewPlainMessageFromString(decBody), nil)
-		if err != nil {
-			return "", err
-		}
+			enc, err := kr.Encrypt(crypto.NewPlainMessageFromString(decBody), nil)
+			if err != nil {
+				return "", err
+			}
 
-		return enc.GetArmored()
+			return enc.GetArmored()
+		})
 	})
 }
 
-func (b *Backend) withAcc(userID string, fn func(acc *account) error) error {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
-
+func (b *unsafeBackend) withAcc(userID string, fn func(acc *account) error) error {
 	acc, ok := b.accounts[userID]
 	if !ok {
 		return fmt.Errorf("account %s not found", userID)
@@ -535,10 +592,7 @@ func (b *Backend) withAcc(userID string, fn func(acc *account) error) error {
 	return fn(acc)
 }
 
-func (b *Backend) withAccEmail(email string, fn func(acc *account) error) error {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
-
+func (b *unsafeBackend) withAccEmail(email string, fn func(acc *account) error) error {
 	for _, acc := range b.accounts {
 		for _, addr := range acc.addresses {
 			if addr.email == email {
@@ -550,10 +604,7 @@ func (b *Backend) withAccEmail(email string, fn func(acc *account) error) error 
 	return fmt.Errorf("account %s not found", email)
 }
 
-func withAcc[T any](b *Backend, userID string, fn func(acc *account) (T, error)) (T, error) {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
-
+func withAcc[T any](b *unsafeBackend, userID string, fn func(acc *account) (T, error)) (T, error) {
 	for _, acc := range b.accounts {
 		if acc.userID == userID {
 			return fn(acc)
@@ -563,10 +614,7 @@ func withAcc[T any](b *Backend, userID string, fn func(acc *account) (T, error))
 	return *new(T), fmt.Errorf("account not found")
 }
 
-func withAccName[T any](b *Backend, username string, fn func(acc *account) (T, error)) (T, error) {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
-
+func withAccName[T any](b *unsafeBackend, username string, fn func(acc *account) (T, error)) (T, error) {
 	for _, acc := range b.accounts {
 		if acc.username == username {
 			return fn(acc)
@@ -576,10 +624,7 @@ func withAccName[T any](b *Backend, username string, fn func(acc *account) (T, e
 	return *new(T), fmt.Errorf("account not found")
 }
 
-func withAccEmail[T any](b *Backend, email string, fn func(acc *account) (T, error)) (T, error) {
-	b.accLock.RLock()
-	defer b.accLock.RUnlock()
-
+func withAccEmail[T any](b *unsafeBackend, email string, fn func(acc *account) (T, error)) (T, error) {
 	for _, acc := range b.accounts {
 		if _, ok := acc.getAddr(email); ok {
 			return fn(acc)
@@ -589,14 +634,8 @@ func withAccEmail[T any](b *Backend, email string, fn func(acc *account) (T, err
 	return *new(T), fmt.Errorf("account not found")
 }
 
-func withAccAuth[T any](b *Backend, authUID, authAcc string, fn func(acc *account) (T, error)) (T, error) {
-	b.accLock.Lock()
-	defer b.accLock.Unlock()
-
+func withAccAuth[T any](b *unsafeBackend, authUID, authAcc string, fn func(acc *account) (T, error)) (T, error) {
 	for _, acc := range b.accounts {
-		acc.authLock.Lock()
-		defer acc.authLock.Unlock()
-
 		val, ok := acc.auth[authUID]
 		if !ok {
 			continue
@@ -612,42 +651,27 @@ func withAccAuth[T any](b *Backend, authUID, authAcc string, fn func(acc *accoun
 	return *new(T), fmt.Errorf("account not found")
 }
 
-func (b *Backend) withMessages(fn func(map[string]*message) error) error {
-	b.msgLock.Lock()
-	defer b.msgLock.Unlock()
-
+func (b *unsafeBackend) withMessages(fn func(map[string]*message) error) error {
 	return fn(b.messages)
 }
 
-func withMessages[T any](b *Backend, fn func(map[string]*message) (T, error)) (T, error) {
-	b.msgLock.Lock()
-	defer b.msgLock.Unlock()
-
+func withMessages[T any](b *unsafeBackend, fn func(map[string]*message) (T, error)) (T, error) {
 	return fn(b.messages)
 }
 
-func withAtts[T any](b *Backend, fn func(map[string]*attachment) (T, error)) (T, error) {
-	b.attLock.Lock()
-	defer b.attLock.Unlock()
-
+func withAtts[T any](b *unsafeBackend, fn func(map[string]*attachment) (T, error)) (T, error) {
 	return fn(b.attachments)
 }
 
-func (b *Backend) withLabels(fn func(map[string]*label) error) error {
-	b.lblLock.Lock()
-	defer b.lblLock.Unlock()
-
+func (b *unsafeBackend) withLabels(fn func(map[string]*label) error) error {
 	return fn(b.labels)
 }
 
-func withLabels[T any](b *Backend, fn func(map[string]*label) (T, error)) (T, error) {
-	b.lblLock.Lock()
-	defer b.lblLock.Unlock()
-
+func withLabels[T any](b *unsafeBackend, fn func(map[string]*label) (T, error)) (T, error) {
 	return fn(b.labels)
 }
 
-func (b *Backend) newUpdate(event update) (ID, error) {
+func (b *unsafeBackend) newUpdate(event update) (ID, error) {
 	return withUpdates(b, func(updates map[ID]update) (ID, error) {
 		updateID := ID(len(updates))
 
@@ -657,9 +681,6 @@ func (b *Backend) newUpdate(event update) (ID, error) {
 	})
 }
 
-func withUpdates[T any](b *Backend, fn func(map[ID]update) (T, error)) (T, error) {
-	b.updatesLock.Lock()
-	defer b.updatesLock.Unlock()
-
+func withUpdates[T any](b *unsafeBackend, fn func(map[ID]update) (T, error)) (T, error) {
 	return fn(b.updates)
 }

--- a/server/backend/report.go
+++ b/server/backend/report.go
@@ -8,22 +8,20 @@ func (b *Backend) CreateCSTicket() string {
 		return ""
 	}
 
-	b.csTicketLock.Lock()
-	defer b.csTicketLock.Unlock()
-
-	token := tokenUUID.String()
-	b.csTicket = append(b.csTicket, token)
-	return token
+	return writeBackendRet(b, func(b *unsafeBackend) string {
+		token := tokenUUID.String()
+		b.csTicket = append(b.csTicket, token)
+		return token
+	})
 }
 
 func (b *Backend) GetCSTicket(token string) bool {
-	b.csTicketLock.Lock()
-	defer b.csTicketLock.Unlock()
-
-	for _, ticket := range b.csTicket {
-		if ticket == token {
-			return true
+	return readBackendRet(b, func(b *unsafeBackend) bool {
+		for _, ticket := range b.csTicket {
+			if ticket == token {
+				return true
+			}
 		}
-	}
-	return false
+		return false
+	})
 }


### PR DESCRIPTION
Access to all the fake server state is now guarded by a single RWLock rather then multiple locks per category. It has been observed in the past that this could lead to deadlocks in Bridge unit tests at random.