### PR TITLE
feat: return typed errors for name and draft conflicts

### DIFF
--- a/link.go
+++ b/link.go
@@ -2,6 +2,8 @@ package proton
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -22,12 +24,39 @@ func (c *Client) GetLink(ctx context.Context, shareID, linkID string) (Link, err
 
 func (c *Client) CreateFile(ctx context.Context, shareID string, req CreateFileReq) (CreateFileRes, error) {
 	var res struct {
+		Code int
 		File CreateFileRes
 	}
 
-	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+	resp, err := c.doRes(ctx, func(r *resty.Request) (*resty.Response, error) {
 		return r.SetResult(&res).SetBody(req).Post("/drive/shares/" + shareID + "/files")
-	}); err != nil {
+	})
+	if err != nil { // if the status code is not 200~299, it's considered an error
+
+		// handle the file or folder name exists error
+		if resp.StatusCode() == http.StatusUnprocessableEntity /* 422 */ {
+			var apiError APIError
+			err := json.Unmarshal(resp.Body(), &apiError)
+			if err != nil {
+				return CreateFileRes{}, err
+			}
+			if apiError.Code == AFileOrFolderNameExist {
+				return CreateFileRes{}, ErrFileNameExist // since we are in CreateFile, so we return this error
+			}
+		}
+
+		// handle draft exists error
+		if resp.StatusCode() == http.StatusConflict /* 409 */ {
+			var apiError APIError
+			err := json.Unmarshal(resp.Body(), &apiError)
+			if err != nil {
+				return CreateFileRes{}, err
+			}
+			if apiError.Code == ADraftExist {
+				return CreateFileRes{}, ErrADraftExist
+			}
+		}
+
 		return CreateFileRes{}, err
 	}
 
@@ -39,9 +68,23 @@ func (c *Client) CreateFolder(ctx context.Context, shareID string, req CreateFol
 		Folder CreateFolderRes
 	}
 
-	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+	resp, err := c.doRes(ctx, func(r *resty.Request) (*resty.Response, error) {
 		return r.SetResult(&res).SetBody(req).Post("/drive/shares/" + shareID + "/folders")
-	}); err != nil {
+	})
+	if err != nil { // if the status code is not 200~299, it's considered an error
+
+		// handle the file or folder name exists error
+		if resp.StatusCode() == http.StatusUnprocessableEntity /* 422 */ {
+			var apiError APIError
+			err := json.Unmarshal(resp.Body(), &apiError)
+			if err != nil {
+				return CreateFolderRes{}, err
+			}
+			if apiError.Code == AFileOrFolderNameExist {
+				return CreateFolderRes{}, ErrFolderNameExist // since we are in CreateFolder, so we return this error
+			}
+		}
+
 		return CreateFolderRes{}, err
 	}
 

--- a/response.go
+++ b/response.go
@@ -31,6 +31,16 @@ const (
 	PaidPlanRequired            Code = 10004
 	AuthRefreshTokenInvalid     Code = 10013
 	HumanValidationInvalidToken Code = 12087
+
+	// ProtonDrive
+	AFileOrFolderNameExist Code = 2500
+	ADraftExist            Code = 2500
+)
+
+var (
+	ErrFileNameExist   = errors.New("a file with that name already exists (Code=2500, Status=422)")
+	ErrFolderNameExist = errors.New("a folder with that name already exists (Code=2500, Status=422)")
+	ErrADraftExist     = errors.New("draft already exists on this revision (Code=2500, Status=409)")
 )
 
 type ErrDetails []byte


### PR DESCRIPTION
Inspect 422 and 409 responses from CreateFile and CreateFolder and
return sentinel errors (ErrFileNameExist, ErrFolderNameExist,
ErrADraftExist) so callers can distinguish name-exists and
draft-exists conditions.
