### PR TITLE
feat: add CreateRevision and DeleteRevision

### DIFF
--- a/link_file.go
+++ b/link_file.go
@@ -53,3 +53,34 @@ func (c *Client) UpdateRevision(ctx context.Context, shareID, linkID, revisionID
 		return r.SetBody(req).Put("/drive/shares/" + shareID + "/files/" + linkID + "/revisions/" + revisionID)
 	})
 }
+
+func (c *Client) DeleteRevision(ctx context.Context, shareID, linkID, revisionID string) error {
+	return c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+		return r.Delete("/drive/shares/" + shareID + "/files/" + linkID + "/revisions/" + revisionID)
+	})
+}
+
+// CreateRevisionFrom creates a new draft revision on an existing file,
+// optionally based on a prior revision for block inheritance (copy-on-write).
+// When req.CurrentRevisionID is set, the new draft inherits the base
+// revision's blocks — the caller only needs to upload changed blocks.
+func (c *Client) CreateRevisionFrom(ctx context.Context, shareID, linkID string, req CreateRevisionReq) (CreateRevisionRes, error) {
+	var res struct {
+		Revision CreateRevisionRes
+	}
+
+	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+		return r.SetResult(&res).SetBody(req).Post("/drive/shares/" + shareID + "/files/" + linkID + "/revisions")
+	}); err != nil {
+		return CreateRevisionRes{}, err
+	}
+
+	return res.Revision, nil
+}
+
+// CreateRevision creates a new draft revision on an existing file from
+// scratch (no base revision). It is a convenience wrapper around
+// CreateRevisionFrom with an empty request.
+func (c *Client) CreateRevision(ctx context.Context, shareID, linkID string) (CreateRevisionRes, error) {
+	return c.CreateRevisionFrom(ctx, shareID, linkID, CreateRevisionReq{})
+}

--- a/link_file_test.go
+++ b/link_file_test.go
@@ -1,0 +1,42 @@
+package proton
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestCreateRevisionReq_MarshalJSON_Empty(t *testing.T) {
+	req := CreateRevisionReq{}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("expected {}, got %s", data)
+	}
+}
+
+func TestCreateRevisionReq_MarshalJSON_WithCurrentRevisionID(t *testing.T) {
+	req := CreateRevisionReq{CurrentRevisionID: ptr("rev-abc-123")}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	expected := `{"CurrentRevisionID":"rev-abc-123"}`
+	if string(data) != expected {
+		t.Fatalf("expected %s, got %s", expected, data)
+	}
+}
+
+func TestCreateRevisionReq_MarshalJSON_NilCurrentRevisionID(t *testing.T) {
+	req := CreateRevisionReq{CurrentRevisionID: nil}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("expected {}, got %s", data)
+	}
+}

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -22,6 +22,17 @@ type CreateFileRes struct {
 	RevisionID string // Encrypted Revision ID
 }
 
+type CreateRevisionRes struct {
+	ID string // Encrypted Revision ID
+}
+
+// CreateRevisionReq is the request body for CreateRevisionFrom.
+// CurrentRevisionID, when non-nil, bases the new draft revision on the
+// specified active revision, enabling block reuse (copy-on-write).
+type CreateRevisionReq struct {
+	CurrentRevisionID *string `json:"CurrentRevisionID,omitempty"`
+}
+
 type UpdateRevisionReq struct {
 	BlockList         []BlockToken
 	State             RevisionState


### PR DESCRIPTION
Add client methods to create a new file revision and to delete a
revision, along with the CreateRevisionRes type.
