### PR TITLE
feat: add CheckAvailableHashes

### DIFF
--- a/link.go
+++ b/link.go
@@ -47,3 +47,21 @@ func (c *Client) CreateFolder(ctx context.Context, shareID string, req CreateFol
 
 	return res.Folder, nil
 }
+
+func (c *Client) CheckAvailableHashes(ctx context.Context, shareID, linkID string, req CheckAvailableHashesReq) (CheckAvailableHashesRes, error) {
+	var res struct {
+		AvailableHashes   []string
+		PendingHashesData []PendingHashData
+	}
+
+	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+		return r.SetResult(&res).SetBody(req).Post("/drive/shares/" + shareID + "/links/" + linkID + "/checkAvailableHashes")
+	}); err != nil {
+		return CheckAvailableHashesRes{}, err
+	}
+
+	return CheckAvailableHashesRes{
+		AvailableHashes:   res.AvailableHashes,
+		PendingHashesData: res.PendingHashesData,
+	}, nil
+}

--- a/link_types.go
+++ b/link_types.go
@@ -182,3 +182,17 @@ const (
 	RevisionStateObsolete
 	RevisionStateDeleted
 )
+
+type CheckAvailableHashesReq struct {
+	Hashes []string
+}
+
+type PendingHashData struct {
+	Hash       []string
+	RevisionID []string
+	LinkID     []string
+}
+type CheckAvailableHashesRes struct {
+	AvailableHashes   []string
+	PendingHashesData []PendingHashData
+}


### PR DESCRIPTION
Add the CheckAvailableHashes client method with its request and
response types for querying which name hashes are available under a
parent link.
