### PR TITLE
fix: widen User.Credit to int64

### DIFF
--- a/user_types.go
+++ b/user_types.go
@@ -11,7 +11,7 @@ type User struct {
 	MaxSpace  uint64
 	MaxUpload uint64
 
-	Credit   int
+	Credit   int64
 	Currency string
 
 	ProductUsedSpace ProductUsedSpace


### PR DESCRIPTION
The Credit field can hold values that exceed the range of a 32-bit int
on some platforms; widen it to int64 to avoid overflow.
