### PR TITLE
fix: issue with slices.SortFunc

### DIFF
--- a/address.go
+++ b/address.go
@@ -2,9 +2,9 @@ package proton
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-resty/resty/v2"
-	"golang.org/x/exp/slices"
 )
 
 func (c *Client) GetAddresses(ctx context.Context) ([]Address, error) {
@@ -18,8 +18,8 @@ func (c *Client) GetAddresses(ctx context.Context) ([]Address, error) {
 		return nil, err
 	}
 
-	slices.SortFunc(res.Addresses, func(a, b Address) bool {
-		return a.Order < b.Order
+	slices.SortFunc(res.Addresses, func(a, b Address) int {
+		return a.Order - b.Order
 	})
 
 	return res.Addresses, nil


### PR DESCRIPTION
> address.go:21:33: in call to slices.SortFunc, type func(a Address, b Address) bool of func(a, b Address) bool {…} does not match inferred type func(a Address, b Address) int for func(a E, b E) int