### PR TITLE
feat: add String methods for AddressStatus and AddressType

### DIFF
--- a/address_types.go
+++ b/address_types.go
@@ -1,5 +1,7 @@
 package proton
 
+import "fmt"
+
 type Address struct {
 	ID    string
 	Email string
@@ -27,6 +29,14 @@ const (
 	AddressStatusDeleting
 )
 
+func (s AddressStatus) String() string {
+	statusStrings := [...]string{"disabled", "enabled", "deleting"}
+	if s < AddressStatusDisabled || s > AddressStatusDeleting {
+		return fmt.Sprintf("Unknown Status (%d)", s)
+	}
+	return statusStrings[s]
+}
+
 type AddressType int
 
 const (
@@ -41,4 +51,14 @@ const (
 // BYOE addresses have sending enabled and are of type `external`.
 func (a Address) IsBYOEAddress() bool {
 	return bool(a.Send) && a.Type == AddressTypeExternal
+}
+
+func (a AddressType) String() string {
+	typeStrings := [...]string{"original", "alias", "custom", "premium", "external"}
+	if a < AddressTypeOriginal || a > AddressTypeExternal {
+		return fmt.Sprintf("Unknown Type (%d)", a)
+	}
+
+	// Proton API defines the start type as `iota + 1`
+	return typeStrings[a-1]
 }


### PR DESCRIPTION
Implement fmt.Stringer for AddressStatus and AddressType so their
values render as human-readable names, with a fallback for unknown
values.
