### PR TITLE
fix(BRIDGE-355): check for nil encoder to prevent panic

### DIFF
--- a/message_encrypt.go
+++ b/message_encrypt.go
@@ -343,11 +343,11 @@ func getCharsetDecoder(r io.Reader, charset string) (io.Reader, error) {
 		}
 	}
 
-	if enc, err := ianaindex.MIME.Encoding(strings.ToLower(charset)); err == nil {
+	if enc, err := ianaindex.MIME.Encoding(strings.ToLower(charset)); enc != nil && err == nil {
 		return enc.NewDecoder().Reader(r), nil
 	}
 
-	if enc, err := ianaindex.MIME.Encoding("cs" + strings.ToLower(charset)); err == nil {
+	if enc, err := ianaindex.MIME.Encoding("cs" + strings.ToLower(charset)); enc != nil && err == nil {
 		return enc.NewDecoder().Reader(r), nil
 	}
 


### PR DESCRIPTION
Although explicitly documented in the package source code (by a former Bridge dev, might I add), we did not perform this check.  Ref: https://github.com/golang/text/blob/master/encoding/ianaindex/ianaindex.go#L75

In rare cases, this would cause a nil pointer deref and subsequent crash on Bridge. 