### PR TITLE
feat(xattr): expose the XAttr struct and retrieval helpers

### DIFF
--- a/link_file_types.go
+++ b/link_file_types.go
@@ -1,5 +1,11 @@
 package proton
 
+import (
+	"encoding/json"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
 type CreateFileReq struct {
 	ParentLinkID string
 
@@ -27,6 +33,53 @@ type UpdateRevisionReq struct {
 	State             RevisionState
 	ManifestSignature string
 	SignatureAddress  string
+	XAttr             string
+}
+
+type RevisionXAttrCommon struct {
+	ModificationTime string
+	Size             int64
+	BlockSizes       []int64
+	Digests          map[string]string
+}
+
+type RevisionXAttr struct {
+	Common RevisionXAttrCommon
+}
+
+func (updateRevisionReq *UpdateRevisionReq) SetEncXAttrString(addrKR, nodeKR *crypto.KeyRing, xAttrCommon *RevisionXAttrCommon) error {
+	// Source
+	// - https://github.com/ProtonMail/WebClients/blob/099a2451b51dea38b5f0e07ec3b8fcce07a88303/packages/shared/lib/interfaces/drive/link.ts#L53
+	// - https://github.com/ProtonMail/WebClients/blob/main/applications/drive/src/app/store/_links/extendedAttributes.ts#L139
+	// XAttr has following JSON structure encrypted by node key:
+	// {
+	//    Common: {
+	//        ModificationTime: "2021-09-16T07:40:54+0000",
+	//        Size: 13283,
+	// 		  BlockSizes: [1,2,3],
+	//        Digests: "sha1 string"
+	//    },
+	// }
+
+	jsonByteArr, err := json.Marshal(RevisionXAttr{
+		Common: *xAttrCommon,
+	})
+	if err != nil {
+		return err
+	}
+
+	encXattr, err := nodeKR.Encrypt(crypto.NewPlainMessage(jsonByteArr), addrKR)
+	if err != nil {
+		return err
+	}
+
+	encXattrString, err := encXattr.GetArmored()
+	if err != nil {
+		return err
+	}
+
+	updateRevisionReq.XAttr = encXattrString
+	return nil
 }
 
 type BlockToken struct {

--- a/link_types.go
+++ b/link_types.go
@@ -2,6 +2,7 @@ package proton
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
@@ -27,6 +28,8 @@ type Link struct {
 	CreateTime     int64 // Link creation time
 	ModifyTime     int64 // Link modification time (on API, real modify date is stored in XAttr)
 	ExpirationTime int64 // Link expiration time
+
+	XAttr string // modification time and size from the file system
 
 	NodeKey                 string // The private NodeKey, used to decrypt any file/folder content.
 	NodePassphrase          string // The passphrase used to unlock the NodeKey, encrypted by the owning Link/Share keyring.
@@ -162,8 +165,35 @@ type RevisionMetadata struct {
 	ManifestSignature string        // Signature of the revision manifest, signed with user's address key of the share.
 	SignatureEmail    string        // Email of the user that signed the revision.
 	State             RevisionState // State of revision
+	XAttr             string        // modification time and size from the file system
 	Thumbnail         Bool          // Whether the revision has a thumbnail
 	ThumbnailHash     string        // Hash of the thumbnail
+}
+
+func (revisionMetadata *RevisionMetadata) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+	if revisionMetadata.XAttr == "" {
+		return nil, nil
+	}
+
+	// decrypt the modification time and size
+	XAttrMsg, err := crypto.NewPGPMessageFromArmored(revisionMetadata.XAttr)
+	if err != nil {
+		return nil, err
+	}
+
+	decXAttr, err := nodeKR.Decrypt(XAttrMsg, addrKR, crypto.GetUnixTime())
+	if err != nil {
+		return nil, err
+	}
+
+	var data RevisionXAttr
+	err = json.Unmarshal(decXAttr.Data, &data)
+	if err != nil {
+		// TODO: if Unmarshal fails, maybe it's because the file system is missing the field?
+		return nil, err
+	}
+
+	return &data.Common, nil
 }
 
 // Revisions are only for files, they represent “versions” of files.
@@ -172,6 +202,32 @@ type Revision struct {
 	RevisionMetadata
 
 	Blocks []Block
+}
+
+func (revision *Revision) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+	if revision.XAttr == "" {
+		return nil, nil
+	}
+
+	// decrypt the modification time and size
+	XAttrMsg, err := crypto.NewPGPMessageFromArmored(revision.XAttr)
+	if err != nil {
+		return nil, err
+	}
+
+	decXAttr, err := nodeKR.Decrypt(XAttrMsg, addrKR, crypto.GetUnixTime())
+	if err != nil {
+		return nil, err
+	}
+
+	var data RevisionXAttr
+	err = json.Unmarshal(decXAttr.Data, &data)
+	if err != nil {
+		// TODO: if Unmarshal fails, maybe it's because the file system is missing the field?
+		return nil, err
+	}
+
+	return &data.Common, nil
 }
 
 type RevisionState int


### PR DESCRIPTION
Expose the extended-attribute types (RevisionXAttrCommon,
RevisionXAttr) and SetEncXAttrString on UpdateRevisionReq. Add the
XAttr field to Link, RevisionMetadata, and Revision, plus
GetDecXAttrString helpers on RevisionMetadata and Revision that
decrypt the XAttr blob into a RevisionXAttrCommon.
