### PR TITLE
feat(block): add block upload verification

### DIFF
--- a/block_types.go
+++ b/block_types.go
@@ -16,18 +16,26 @@ type Block struct {
 
 type BlockUploadReq struct {
 	AddressID  string
-	ShareID    string
+	ShareID    string `json:",omitempty"`
+	VolumeID   string `json:",omitempty"`
 	LinkID     string
 	RevisionID string
 
-	BlockList []BlockUploadInfo
+	BlockList     []BlockUploadInfo `json:"BlockList"`
+	ThumbnailList []interface{}     `json:"ThumbnailList,omitempty"`
+}
+
+// BlockVerifier holds the verification token for a block upload.
+type BlockVerifier struct {
+	Token string
 }
 
 type BlockUploadInfo struct {
 	Index        int
-	Size         int64
+	Size         int64 `json:",omitempty"`
 	EncSignature string
-	Hash         string
+	Hash         string         `json:",omitempty"`
+	Verifier     *BlockVerifier `json:",omitempty"`
 }
 
 type BlockUploadLink struct {

--- a/link_file.go
+++ b/link_file.go
@@ -53,3 +53,24 @@ func (c *Client) UpdateRevision(ctx context.Context, shareID, linkID, revisionID
 		return r.SetBody(req).Put("/drive/shares/" + shareID + "/files/" + linkID + "/revisions/" + revisionID)
 	})
 }
+
+// VerificationData holds the server-provided verification code and
+// content key packet for block upload verification.
+type VerificationData struct {
+	VerificationCode string
+	ContentKeyPacket string
+}
+
+// GetVerificationData fetches the verification code for a revision.
+// The verification code is used to compute per-block verification tokens.
+func (c *Client) GetVerificationData(ctx context.Context, shareID, linkID, revisionID string) (VerificationData, error) {
+	var res VerificationData
+
+	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+		return r.SetResult(&res).Get("/drive/shares/" + shareID + "/links/" + linkID + "/revisions/" + revisionID + "/verification")
+	}); err != nil {
+		return VerificationData{}, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Add VolumeID to BlockUploadReq (alongside ShareID, both omitempty) and
an optional Verifier token on BlockUploadInfo. Add GetVerificationData
to fetch the server-provided verification code used to compute
per-block verification tokens.
