### PR TITLE
feat: add MoveLink support

### DIFF
--- a/link.go
+++ b/link.go
@@ -20,6 +20,20 @@ func (c *Client) GetLink(ctx context.Context, shareID, linkID string) (Link, err
 	return res.Link, nil
 }
 
+func (c *Client) MoveLink(ctx context.Context, shareID, linkID string, req MoveLinkReq) error {
+	var res struct {
+		Code int
+	}
+
+	if err := c.do(ctx, func(r *resty.Request) (*resty.Response, error) {
+		return r.SetResult(&res).SetBody(req).Put("/drive/shares/" + shareID + "/links/" + linkID + "/move")
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Client) CreateFile(ctx context.Context, shareID string, req CreateFileReq) (CreateFileRes, error) {
 	var res struct {
 		File CreateFileRes

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -37,6 +37,38 @@ func GetNameHash(name string, hashKey []byte) (string, error) {
 	return hex.EncodeToString(mac.Sum(nil)), nil
 }
 
+type MoveLinkReq struct {
+	ParentLinkID string
+
+	Name                    string // Encrypted File Name
+	OriginalHash            string // Old Encrypted File Name Hash
+	Hash                    string // Encrypted File Name Hash by using parent's NodeHashKey
+	NodePassphrase          string // The passphrase used to unlock the NodeKey, encrypted by the owning Link/Share keyring.
+	NodePassphraseSignature string // The signature of the NodePassphrase
+
+	SignatureAddress string // Signature email address used to sign passphrase and name
+}
+
+func (moveLinkReq *MoveLinkReq) SetName(name string, addrKR, nodeKR *crypto.KeyRing) error {
+	encNameString, err := getEncryptedName(name, addrKR, nodeKR)
+	if err != nil {
+		return err
+	}
+
+	moveLinkReq.Name = encNameString
+	return nil
+}
+
+func (moveLinkReq *MoveLinkReq) SetHash(name string, hashKey []byte) error {
+	nameHash, err := GetNameHash(name, hashKey)
+	if err != nil {
+		return err
+	}
+
+	moveLinkReq.Hash = nameHash
+	return nil
+}
+
 type CreateFileReq struct {
 	ParentLinkID string
 

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -1,5 +1,42 @@
 package proton
 
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// getEncryptedName encrypts name with the node keyring, signs it with the
+// address keyring, and returns the armored ciphertext.
+func getEncryptedName(name string, addrKR, nodeKR *crypto.KeyRing) (string, error) {
+	clearTextName := crypto.NewPlainMessageFromString(name)
+
+	encName, err := nodeKR.Encrypt(clearTextName, addrKR)
+	if err != nil {
+		return "", err
+	}
+
+	encNameString, err := encName.GetArmored()
+	if err != nil {
+		return "", err
+	}
+
+	return encNameString, nil
+}
+
+// GetNameHash returns the hex-encoded HMAC-SHA256 of name keyed by hashKey.
+func GetNameHash(name string, hashKey []byte) (string, error) {
+	mac := hmac.New(sha256.New, hashKey)
+	_, err := mac.Write([]byte(name))
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
 type CreateFileReq struct {
 	ParentLinkID string
 


### PR DESCRIPTION
Add the MoveLink client method and MoveLinkReq, with SetName and
SetHash helpers for building the encrypted name and name hash.

Depends-on: #165 (feat/link_file_types)
