### PR TITLE
feat: add CreateFileReq builder helpers

### DIFF
--- a/link_file_test.go
+++ b/link_file_test.go
@@ -1,0 +1,29 @@
+package proton_test
+
+import (
+	"testing"
+
+	"github.com/ProtonMail/go-proton-api"
+)
+
+func Test_HMAC(t *testing.T) {
+	hashKey := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	check := func(t *testing.T, str, ans string) {
+		ret, err := proton.GetNameHash(str, hashKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ret != ans {
+			t.Fatal("Mismatching HMAC", ans, ret)
+		}
+	}
+
+	check(t, "garçon", "02ef4861a4b9f833aa104a8210f5eb338e231c9532d9c2551aaf76bafb511208")
+	check(t, "apă", "fd80de16c11bdcea2783274f6b7f334093ef95d58c7381c615005614ed77dc94")
+	check(t, "bala", "35733f41071d4997876b5bb54acc1d587646bdf1251f9b9c49ee9dc023a69962")
+	check(t, "țânțar", "4f4dee0cd87928027982c6ca280d2c7661073082ed46a82c111880126b0c3e14")
+	check(t, "întuneric", "6bed2bff136e165ad54d0a2a9a549481c88aca55d567c93123e0e5b876c291b2")
+	check(t, "mädchen", "2b112b1b7ac4fd9dae5a2acd8fcf2e905bd92a06a95dc4495fa012bda93e8607")
+	check(t, "integrationTestImage.png", "2e700ef3b52379a9277ac48bcfc5dff56e6927274267a0df4673f4f21e5d04d6")
+}

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -3,6 +3,7 @@ package proton
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
@@ -52,6 +53,53 @@ type CreateFileReq struct {
 	NodePassphraseSignature string // The signature of the NodePassphrase
 
 	SignatureAddress string // Signature email address used to sign passphrase and name
+}
+
+func (createFileReq *CreateFileReq) SetName(name string, addrKR, nodeKR *crypto.KeyRing) error {
+	encNameString, err := getEncryptedName(name, addrKR, nodeKR)
+	if err != nil {
+		return err
+	}
+
+	createFileReq.Name = encNameString
+	return nil
+}
+
+func (createFileReq *CreateFileReq) SetHash(name string, hashKey []byte) error {
+	nameHash, err := GetNameHash(name, hashKey)
+	if err != nil {
+		return err
+	}
+
+	createFileReq.Hash = nameHash
+
+	return nil
+}
+
+func (createFileReq *CreateFileReq) SetContentKeyPacketAndSignature(kr *crypto.KeyRing) (*crypto.SessionKey, error) {
+	newSessionKey, err := crypto.GenerateSessionKey()
+	if err != nil {
+		return nil, err
+	}
+
+	encSessionKey, err := kr.EncryptSessionKey(newSessionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionKeyPlainMessage := crypto.NewPlainMessage(newSessionKey.Key)
+	sessionKeySignature, err := kr.SignDetached(sessionKeyPlainMessage)
+	if err != nil {
+		return nil, err
+	}
+	armoredSessionKeySignature, err := sessionKeySignature.GetArmored()
+	if err != nil {
+		return nil, err
+	}
+
+	createFileReq.ContentKeyPacket = base64.StdEncoding.EncodeToString(encSessionKey)
+	createFileReq.ContentKeyPacketSignature = armoredSessionKeySignature
+	return newSessionKey, nil
 }
 
 type CreateFileRes struct {

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -1,5 +1,42 @@
 package proton
 
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// getEncryptedName encrypts name with the node keyring, signs it with the
+// address keyring, and returns the armored ciphertext.
+func getEncryptedName(name string, addrKR, nodeKR *crypto.KeyRing) (string, error) {
+	clearTextName := crypto.NewPlainMessageFromString(name)
+
+	encName, err := nodeKR.Encrypt(clearTextName, addrKR)
+	if err != nil {
+		return "", err
+	}
+
+	encNameString, err := encName.GetArmored()
+	if err != nil {
+		return "", err
+	}
+
+	return encNameString, nil
+}
+
+// GetNameHash returns the hex-encoded HMAC-SHA256 of name keyed by hashKey.
+func GetNameHash(name string, hashKey []byte) (string, error) {
+	mac := hmac.New(sha256.New, hashKey)
+	_, err := mac.Write([]byte(name))
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
 type CreateFileReq struct {
 	ParentLinkID string
 


### PR DESCRIPTION
Add SetName, SetHash, and SetContentKeyPacketAndSignature helpers to
CreateFileReq for constructing the encrypted request fields, plus
tests.

Depends-on: #165 (feat/link_file_types)
