### PR TITLE
feat: add CreateFolderReq builder helpers

### DIFF
--- a/link_file_types.go
+++ b/link_file_types.go
@@ -1,5 +1,42 @@
 package proton
 
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
+// getEncryptedName encrypts name with the node keyring, signs it with the
+// address keyring, and returns the armored ciphertext.
+func getEncryptedName(name string, addrKR, nodeKR *crypto.KeyRing) (string, error) {
+	clearTextName := crypto.NewPlainMessageFromString(name)
+
+	encName, err := nodeKR.Encrypt(clearTextName, addrKR)
+	if err != nil {
+		return "", err
+	}
+
+	encNameString, err := encName.GetArmored()
+	if err != nil {
+		return "", err
+	}
+
+	return encNameString, nil
+}
+
+// GetNameHash returns the hex-encoded HMAC-SHA256 of name keyed by hashKey.
+func GetNameHash(name string, hashKey []byte) (string, error) {
+	mac := hmac.New(sha256.New, hashKey)
+	_, err := mac.Write([]byte(name))
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
 type CreateFileReq struct {
 	ParentLinkID string
 

--- a/link_folder_types.go
+++ b/link_folder_types.go
@@ -1,5 +1,9 @@
 package proton
 
+import (
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
 type CreateFolderReq struct {
 	ParentLinkID string
 
@@ -13,6 +17,51 @@ type CreateFolderReq struct {
 	NodePassphraseSignature string
 
 	SignatureAddress string
+}
+
+func (createFolderReq *CreateFolderReq) SetName(name string, addrKR, nodeKR *crypto.KeyRing) error {
+	encNameString, err := getEncryptedName(name, addrKR, nodeKR)
+	if err != nil {
+		return err
+	}
+
+	createFolderReq.Name = encNameString
+
+	return nil
+}
+
+func (createFolderReq *CreateFolderReq) SetHash(name string, hashKey []byte) error {
+	nameHash, err := GetNameHash(name, hashKey)
+	if err != nil {
+		return err
+	}
+
+	createFolderReq.Hash = nameHash
+
+	return nil
+}
+
+func (createFolderReq *CreateFolderReq) SetNodeHashKey(parentNodeKey *crypto.KeyRing) error {
+	token, err := crypto.RandomToken(32)
+	if err != nil {
+		return err
+	}
+
+	tokenMessage := crypto.NewPlainMessage(token)
+
+	encToken, err := parentNodeKey.Encrypt(tokenMessage, parentNodeKey)
+	if err != nil {
+		return err
+	}
+
+	nodeHashKey, err := encToken.GetArmored()
+	if err != nil {
+		return err
+	}
+
+	createFolderReq.NodeHashKey = nodeHashKey
+
+	return nil
 }
 
 type CreateFolderRes struct {


### PR DESCRIPTION
Add SetName and SetHash helpers to CreateFolderReq for constructing
the encrypted name and name hash.

Depends-on: #165 (feat/link_file_types)
