### PR TITLE
feat(xattr): generic unknown-section passthrough on RevisionXAttr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -255,3 +255,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -41,13 +41,82 @@ type RevisionXAttrCommon struct {
 	Size             int64
 	BlockSizes       []int64
 	Digests          map[string]string
+	// Mode removed — migrated to the POSIX section (proton-utils' PosixXAttr).
 }
 
+// RevisionXAttr is the decoded XAttr blob. Common is Proton's typed schema;
+// Extra preserves every other top-level section verbatim so a decode→encode
+// round-trip never drops data written by other clients (Media, Camera,
+// Location) or the shared POSIX section. Callers read/write their own
+// namespaced sections through Extra.
 type RevisionXAttr struct {
+	Common RevisionXAttrCommon
+	Extra  map[string]json.RawMessage `json:"-"` // unmodeled top-level sections
+}
+
+// revisionXAttrAlias has the same modeled fields but no Marshal/Unmarshal
+// methods, so encoding/json can (de)serialize Common without recursing into
+// RevisionXAttr's custom codec.
+type revisionXAttrAlias struct {
 	Common RevisionXAttrCommon
 }
 
-func (updateRevisionReq *UpdateRevisionReq) SetEncXAttrString(addrKR, nodeKR *crypto.KeyRing, xAttrCommon *RevisionXAttrCommon) error {
+// MarshalJSON encodes the typed Common section plus every section held in
+// Extra. Top-level keys are emitted in ascending lexicographic order (map-key
+// sorting by encoding/json), so output is byte-deterministic for a given set
+// of sections. The typed Common wins over any stray Extra["Common"].
+func (x RevisionXAttr) MarshalJSON() ([]byte, error) {
+	m := make(map[string]json.RawMessage, len(x.Extra)+1)
+	for k, v := range x.Extra {
+		m[k] = v
+	}
+
+	common, err := json.Marshal(revisionXAttrAlias{Common: x.Common})
+	if err != nil {
+		return nil, err
+	}
+
+	// common is `{"Common":{...}}`; lift its single member into m so the typed
+	// Common overrides any Extra["Common"].
+	var tmp map[string]json.RawMessage
+	if err := json.Unmarshal(common, &tmp); err != nil {
+		return nil, err
+	}
+	for k, v := range tmp {
+		m[k] = v
+	}
+
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON decodes the Common section into the typed field and places
+// every other top-level section into Extra as verbatim raw JSON. A blob with
+// no Common yields a zero Common; an empty object leaves Extra nil.
+func (x *RevisionXAttr) UnmarshalJSON(data []byte) error {
+	var a revisionXAttrAlias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	x.Common = a.Common
+
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(data, &all); err != nil {
+		return err
+	}
+	delete(all, "Common")
+	if len(all) > 0 {
+		x.Extra = all
+	}
+
+	return nil
+}
+
+// SetEncXAttrString marshals the full RevisionXAttr (Common + Extra),
+// encrypts it with the node keyring, signs it with the address keyring, and
+// stores the armored result on the request. The custom MarshalJSON emits every
+// unmodeled section held in Extra (e.g. the POSIX section), so callers write
+// their namespaced metadata through Extra.
+func (updateRevisionReq *UpdateRevisionReq) SetEncXAttrString(addrKR, nodeKR *crypto.KeyRing, xAttr *RevisionXAttr) error {
 	// Source
 	// - https://github.com/ProtonMail/WebClients/blob/099a2451b51dea38b5f0e07ec3b8fcce07a88303/packages/shared/lib/interfaces/drive/link.ts#L53
 	// - https://github.com/ProtonMail/WebClients/blob/main/applications/drive/src/app/store/_links/extendedAttributes.ts#L139
@@ -61,9 +130,7 @@ func (updateRevisionReq *UpdateRevisionReq) SetEncXAttrString(addrKR, nodeKR *cr
 	//    },
 	// }
 
-	jsonByteArr, err := json.Marshal(RevisionXAttr{
-		Common: *xAttrCommon,
-	})
+	jsonByteArr, err := json.Marshal(xAttr)
 	if err != nil {
 		return err
 	}

--- a/link_file_types.go
+++ b/link_file_types.go
@@ -1,5 +1,11 @@
 package proton
 
+import (
+	"encoding/json"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+)
+
 type CreateFileReq struct {
 	ParentLinkID string
 
@@ -27,6 +33,53 @@ type UpdateRevisionReq struct {
 	State             RevisionState
 	ManifestSignature string
 	SignatureAddress  string
+	XAttr             string
+}
+
+type RevisionXAttrCommon struct {
+	ModificationTime string
+	Size             int64
+	BlockSizes       []int64
+	Digests          map[string]string
+}
+
+type RevisionXAttr struct {
+	Common RevisionXAttrCommon
+}
+
+func (updateRevisionReq *UpdateRevisionReq) SetEncXAttrString(addrKR, nodeKR *crypto.KeyRing, xAttrCommon *RevisionXAttrCommon) error {
+	// Source
+	// - https://github.com/ProtonMail/WebClients/blob/099a2451b51dea38b5f0e07ec3b8fcce07a88303/packages/shared/lib/interfaces/drive/link.ts#L53
+	// - https://github.com/ProtonMail/WebClients/blob/main/applications/drive/src/app/store/_links/extendedAttributes.ts#L139
+	// XAttr has following JSON structure encrypted by node key:
+	// {
+	//    Common: {
+	//        ModificationTime: "2021-09-16T07:40:54+0000",
+	//        Size: 13283,
+	// 		  BlockSizes: [1,2,3],
+	//        Digests: "sha1 string"
+	//    },
+	// }
+
+	jsonByteArr, err := json.Marshal(RevisionXAttr{
+		Common: *xAttrCommon,
+	})
+	if err != nil {
+		return err
+	}
+
+	encXattr, err := nodeKR.Encrypt(crypto.NewPlainMessage(jsonByteArr), addrKR)
+	if err != nil {
+		return err
+	}
+
+	encXattrString, err := encXattr.GetArmored()
+	if err != nil {
+		return err
+	}
+
+	updateRevisionReq.XAttr = encXattrString
+	return nil
 }
 
 type BlockToken struct {

--- a/link_file_xattr_prop_test.go
+++ b/link_file_xattr_prop_test.go
@@ -1,0 +1,436 @@
+package proton_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ProtonMail/go-proton-api"
+	"pgregory.net/rapid"
+)
+
+// canonicalJSON normalizes a JSON blob into a byte-deterministic form: object
+// keys sorted, insignificant whitespace removed, numbers re-rendered. Two
+// blobs are semantically equal iff their canonical forms are byte-equal.
+func canonicalJSON(t *rapid.T, b []byte) string {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		t.Fatalf("canonicalize: unmarshal %q: %v", b, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("canonicalize: marshal: %v", err)
+	}
+	return string(out)
+}
+
+// genJSONValue draws an arbitrary JSON value (scalar, array, or object up to
+// the given nesting depth) as raw JSON bytes. It is the section-value
+// generator for the round-trip property: the fork must preserve any value an
+// unmodeled section carries.
+func genJSONValue(t *rapid.T, depth int) json.RawMessage {
+	kinds := []string{"string", "int", "float", "bool", "null"}
+	if depth > 0 {
+		kinds = append(kinds, "array", "object")
+	}
+
+	switch rapid.SampledFrom(kinds).Draw(t, "kind") {
+	case "string":
+		b, _ := json.Marshal(rapid.String().Draw(t, "str"))
+		return b
+	case "int":
+		b, _ := json.Marshal(rapid.Int64().Draw(t, "int"))
+		return b
+	case "float":
+		b, _ := json.Marshal(rapid.Float64Range(-1e9, 1e9).Draw(t, "float"))
+		return b
+	case "bool":
+		b, _ := json.Marshal(rapid.Bool().Draw(t, "bool"))
+		return b
+	case "array":
+		n := rapid.IntRange(0, 4).Draw(t, "arrlen")
+		arr := make([]json.RawMessage, n)
+		for i := range arr {
+			arr[i] = genJSONValue(t, depth-1)
+		}
+		b, _ := json.Marshal(arr)
+		return b
+	case "object":
+		n := rapid.IntRange(0, 4).Draw(t, "objlen")
+		m := make(map[string]json.RawMessage, n)
+		for i := 0; i < n; i++ {
+			k := rapid.StringMatching(`[A-Za-z0-9_]{1,10}`).Draw(t, "objkey")
+			m[k] = genJSONValue(t, depth-1)
+		}
+		b, _ := json.Marshal(m)
+		return b
+	default: // "null"
+		return json.RawMessage("null")
+	}
+}
+
+// genCommon draws an arbitrary but schema-valid RevisionXAttrCommon (only the
+// modeled fields, so the typed decode→encode of Common is faithful).
+func genCommon(t *rapid.T) proton.RevisionXAttrCommon {
+	var blockSizes []int64
+	if rapid.Bool().Draw(t, "hasBlocks") {
+		n := rapid.IntRange(0, 4).Draw(t, "nBlocks")
+		blockSizes = make([]int64, n)
+		for i := range blockSizes {
+			blockSizes[i] = rapid.Int64().Draw(t, "blockSize")
+		}
+	}
+
+	var digests map[string]string
+	if rapid.Bool().Draw(t, "hasDigests") {
+		digests = make(map[string]string)
+		n := rapid.IntRange(0, 3).Draw(t, "nDigests")
+		for i := 0; i < n; i++ {
+			k := rapid.StringMatching(`[A-Za-z0-9]{1,8}`).Draw(t, "digestKey")
+			digests[k] = rapid.String().Draw(t, "digestVal")
+		}
+	}
+
+	return proton.RevisionXAttrCommon{
+		ModificationTime: rapid.String().Draw(t, "mtime"),
+		Size:             rapid.Int64().Draw(t, "size"),
+		BlockSizes:       blockSizes,
+		Digests:          digests,
+	}
+}
+
+// TestProperty1_UnknownSectionsRoundTrip is the headline round-trip property:
+// a blob with a valid Common plus an arbitrary set of unmodeled top-level
+// sections survives UnmarshalJSON→MarshalJSON byte-equivalently under
+// canonicalized JSON, with every unmodeled section preserved.
+//
+// Property 1: Unknown sections survive round-trip byte-equivalently.
+// **Validates: Requirements 1.4**
+func TestProperty1_UnknownSectionsRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		commonBytes, err := json.Marshal(genCommon(t))
+		if err != nil {
+			t.Fatalf("marshal Common: %v", err)
+		}
+
+		input := map[string]json.RawMessage{"Common": commonBytes}
+
+		// Key generator biased toward the real-world sections other Proton
+		// clients write, plus arbitrary keys to fuzz the space.
+		keyGen := rapid.OneOf(
+			rapid.SampledFrom([]string{"Media", "Camera", "Location", "POSIX"}),
+			rapid.StringMatching(`[A-Za-z0-9_]{1,12}`),
+		)
+
+		nExtra := rapid.IntRange(0, 5).Draw(t, "nExtra")
+		for i := 0; i < nExtra; i++ {
+			k := keyGen.Draw(t, "sectionKey")
+			if k == "Common" {
+				continue // Common is the one typed section; never an Extra.
+			}
+			input[k] = genJSONValue(t, 3)
+		}
+
+		inputBytes, err := json.Marshal(input)
+		if err != nil {
+			t.Fatalf("marshal input blob: %v", err)
+		}
+
+		var x proton.RevisionXAttr
+		if err := json.Unmarshal(inputBytes, &x); err != nil {
+			t.Fatalf("UnmarshalJSON: %v", err)
+		}
+
+		outBytes, err := json.Marshal(x)
+		if err != nil {
+			t.Fatalf("MarshalJSON: %v", err)
+		}
+
+		if got, want := canonicalJSON(t, outBytes), canonicalJSON(t, inputBytes); got != want {
+			t.Fatalf("round-trip not byte-equivalent:\n input: %s\noutput: %s", want, got)
+		}
+
+		// Every unmodeled section must be preserved verbatim in Extra.
+		for k, v := range input {
+			if k == "Common" {
+				continue
+			}
+			raw, ok := x.Extra[k]
+			if !ok {
+				t.Fatalf("section %q dropped from Extra", k)
+			}
+			if got, want := canonicalJSON(t, raw), canonicalJSON(t, v); got != want {
+				t.Fatalf("section %q not preserved:\n want: %s\n got:  %s", k, want, got)
+			}
+		}
+	})
+}
+
+// TestRevisionXAttr_StrayExtraCommon covers Requirement 1.6: a stray
+// Extra["Common"] alongside the typed Common is discarded on encode — the
+// typed Common wins — while sibling sections survive.
+func TestRevisionXAttr_StrayExtraCommon(t *testing.T) {
+	typed := proton.RevisionXAttrCommon{ModificationTime: "2021-09-16T07:40:54+0000", Size: 1234}
+	typedBytes, err := json.Marshal(typed)
+	if err != nil {
+		t.Fatalf("marshal typed Common: %v", err)
+	}
+
+	x := proton.RevisionXAttr{
+		Common: typed,
+		Extra: map[string]json.RawMessage{
+			"Common": json.RawMessage(`{"Size":9999,"Bogus":true}`),
+			"Media":  json.RawMessage(`{"Width":4032,"Height":3024}`),
+		},
+	}
+
+	out, err := json.Marshal(x)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	if string(decoded["Common"]) != string(typedBytes) {
+		t.Fatalf("stray Extra[\"Common\"] not discarded: got %s, want %s", decoded["Common"], typedBytes)
+	}
+	if _, ok := decoded["Media"]; !ok {
+		t.Fatal("sibling Media section dropped")
+	}
+}
+
+// TestRevisionXAttr_NoCommon covers Requirement 1.7: a blob with no Common
+// section decodes to a zero Common with every section placed into Extra.
+func TestRevisionXAttr_NoCommon(t *testing.T) {
+	input := []byte(`{"Media":{"Width":100},"POSIX":{"Mode":493}}`)
+
+	var x proton.RevisionXAttr
+	if err := json.Unmarshal(input, &x); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(x.Common, proton.RevisionXAttrCommon{}) {
+		t.Fatalf("expected zero Common, got %+v", x.Common)
+	}
+	for _, k := range []string{"Media", "POSIX"} {
+		if _, ok := x.Extra[k]; !ok {
+			t.Fatalf("section %q not placed into Extra", k)
+		}
+	}
+	if _, ok := x.Extra["Common"]; ok {
+		t.Fatal("Common must never appear in Extra")
+	}
+}
+
+// TestRevisionXAttr_EmptyObject covers Requirement 1.8: an empty JSON object
+// decodes to a zero Common and leaves Extra nil.
+func TestRevisionXAttr_EmptyObject(t *testing.T) {
+	var x proton.RevisionXAttr
+	if err := json.Unmarshal([]byte(`{}`), &x); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(x.Common, proton.RevisionXAttrCommon{}) {
+		t.Fatalf("expected zero Common, got %+v", x.Common)
+	}
+	if x.Extra != nil {
+		t.Fatalf("expected nil Extra, got %v", x.Extra)
+	}
+}
+
+// TestProperty1_MarshalDeterminism is the determinism facet of Property 1:
+// repeated MarshalJSON of the same RevisionXAttr yields byte-identical output,
+// and the top-level keys of that output are emitted in ascending lexicographic
+// order. Deterministic, sorted output is what makes the round-trip byte
+// comparison in TestProperty1_UnknownSectionsRoundTrip well-defined.
+//
+// Property 1 (determinism facet): top-level keys emitted in ascending
+// lexicographic order.
+// **Validates: Requirements 1.3, 1.4**
+func TestProperty1_MarshalDeterminism(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		x := proton.RevisionXAttr{Common: genCommon(t)}
+
+		// Draw an arbitrary set of unmodeled sections into Extra.
+		keyGen := rapid.OneOf(
+			rapid.SampledFrom([]string{"Media", "Camera", "Location", "POSIX"}),
+			rapid.StringMatching(`[A-Za-z0-9_]{1,12}`),
+		)
+		nExtra := rapid.IntRange(0, 6).Draw(t, "nExtra")
+		for i := 0; i < nExtra; i++ {
+			k := keyGen.Draw(t, "sectionKey")
+			if k == "Common" {
+				continue // Common is the typed section, never an Extra.
+			}
+			if x.Extra == nil {
+				x.Extra = make(map[string]json.RawMessage)
+			}
+			x.Extra[k] = genJSONValue(t, 3)
+		}
+
+		first, err := json.Marshal(x)
+		if err != nil {
+			t.Fatalf("MarshalJSON: %v", err)
+		}
+
+		// Repeated marshaling of the same section set is byte-identical.
+		for i := 0; i < 4; i++ {
+			again, err := json.Marshal(x)
+			if err != nil {
+				t.Fatalf("MarshalJSON (repeat %d): %v", i, err)
+			}
+			if !bytes.Equal(first, again) {
+				t.Fatalf("MarshalJSON not deterministic:\n first: %s\nrepeat: %s", first, again)
+			}
+		}
+
+		// Top-level keys must appear in ascending lexicographic order.
+		keys := topLevelKeyOrder(t, first)
+		if !sort.StringsAreSorted(keys) {
+			t.Fatalf("top-level keys not in ascending order: %v (blob: %s)", keys, first)
+		}
+	})
+}
+
+// topLevelKeyOrder returns the top-level object keys of a JSON blob in the
+// order they appear in the byte stream, using a streaming decoder (the
+// order-preserving read encoding/json's map marshaling does not otherwise
+// expose).
+func topLevelKeyOrder(t *rapid.T, b []byte) []string {
+	dec := json.NewDecoder(bytes.NewReader(b))
+
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("decode open: %v", err)
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		t.Fatalf("expected top-level object, got %v", tok)
+	}
+
+	var keys []string
+	depth := 0
+	for dec.More() || depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("decode token: %v", err)
+		}
+		switch v := tok.(type) {
+		case json.Delim:
+			switch v {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		case string:
+			if depth == 0 {
+				keys = append(keys, v)
+				// Consume this key's value so the next string we see at
+				// depth 0 is the next key, not a nested string.
+				if err := skipValue(dec); err != nil {
+					t.Fatalf("skip value: %v", err)
+				}
+			}
+		}
+	}
+	return keys
+}
+
+// skipValue consumes exactly one JSON value from dec, descending through
+// nested objects and arrays so the caller resumes at the following key.
+func skipValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	d, ok := tok.(json.Delim)
+	if !ok {
+		return nil // scalar value, already consumed
+	}
+	depth := 1
+	if d != '{' && d != '[' {
+		return nil
+	}
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if d, ok := tok.(json.Delim); ok {
+			switch d {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
+}
+
+// TestRevisionXAttr_CommonMediaPosixLossless covers the lossless unit case: a
+// blob carrying Common, Media, and POSIX sections decodes then encodes back to
+// the same canonical JSON, with the typed Common preserved and both unmodeled
+// sections (Media, POSIX) round-tripped verbatim through Extra.
+func TestRevisionXAttr_CommonMediaPosixLossless(t *testing.T) {
+	input := []byte(`{` +
+		`"Common":{"ModificationTime":"2021-09-16T07:40:54+0000","Size":13283,"BlockSizes":[1234,5678],"Digests":{"SHA1":"abc123"}},` +
+		`"Media":{"Width":4032,"Height":3024,"Duration":0},` +
+		`"POSIX":{"Mode":493}` +
+		`}`)
+
+	var x proton.RevisionXAttr
+	if err := json.Unmarshal(input, &x); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+
+	// Typed Common decoded faithfully.
+	wantCommon := proton.RevisionXAttrCommon{
+		ModificationTime: "2021-09-16T07:40:54+0000",
+		Size:             13283,
+		BlockSizes:       []int64{1234, 5678},
+		Digests:          map[string]string{"SHA1": "abc123"},
+	}
+	if !reflect.DeepEqual(x.Common, wantCommon) {
+		t.Fatalf("Common decoded wrong:\n want: %+v\n got:  %+v", wantCommon, x.Common)
+	}
+
+	// Media and POSIX preserved verbatim in Extra; Common never in Extra.
+	for _, k := range []string{"Media", "POSIX"} {
+		if _, ok := x.Extra[k]; !ok {
+			t.Fatalf("section %q not placed into Extra", k)
+		}
+	}
+	if _, ok := x.Extra["Common"]; ok {
+		t.Fatal("Common must never appear in Extra")
+	}
+
+	// Encode losslessly: output equals input under canonicalized JSON.
+	out, err := json.Marshal(x)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if got, want := canonicalBytes(t, out), canonicalBytes(t, input); got != want {
+		t.Fatalf("encode not lossless:\n input: %s\noutput: %s", want, got)
+	}
+}
+
+// canonicalBytes is the non-rapid twin of canonicalJSON: it normalizes a JSON
+// blob (keys sorted, whitespace removed) for use in plain unit tests.
+func canonicalBytes(t *testing.T, b []byte) string {
+	t.Helper()
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		t.Fatalf("canonicalize: unmarshal %q: %v", b, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("canonicalize: marshal: %v", err)
+	}
+	return string(out)
+}

--- a/link_types.go
+++ b/link_types.go
@@ -170,7 +170,10 @@ type RevisionMetadata struct {
 	ThumbnailHash     string        // Hash of the thumbnail
 }
 
-func (revisionMetadata *RevisionMetadata) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+// GetDecXAttrString decrypts and returns the full RevisionXAttr, including
+// Extra (unmodeled sections such as the POSIX section). Returns nil when no
+// XAttr is present.
+func (revisionMetadata *RevisionMetadata) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttr, error) {
 	if revisionMetadata.XAttr == "" {
 		return nil, nil
 	}
@@ -193,7 +196,7 @@ func (revisionMetadata *RevisionMetadata) GetDecXAttrString(addrKR, nodeKR *cryp
 		return nil, err
 	}
 
-	return &data.Common, nil
+	return &data, nil
 }
 
 // Revisions are only for files, they represent “versions” of files.
@@ -204,7 +207,10 @@ type Revision struct {
 	Blocks []Block
 }
 
-func (revision *Revision) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+// GetDecXAttrString decrypts and returns the full RevisionXAttr, including
+// Extra (unmodeled sections such as the POSIX section). Returns nil when no
+// XAttr is present.
+func (revision *Revision) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttr, error) {
 	if revision.XAttr == "" {
 		return nil, nil
 	}
@@ -227,7 +233,7 @@ func (revision *Revision) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*Re
 		return nil, err
 	}
 
-	return &data.Common, nil
+	return &data, nil
 }
 
 type RevisionState int

--- a/link_types.go
+++ b/link_types.go
@@ -2,6 +2,7 @@ package proton
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
@@ -27,6 +28,8 @@ type Link struct {
 	CreateTime     int64 // Link creation time
 	ModifyTime     int64 // Link modification time (on API, real modify date is stored in XAttr)
 	ExpirationTime int64 // Link expiration time
+
+	XAttr string // modification time and size from the file system
 
 	NodeKey                 string // The private NodeKey, used to decrypt any file/folder content.
 	NodePassphrase          string // The passphrase used to unlock the NodeKey, encrypted by the owning Link/Share keyring.
@@ -162,8 +165,35 @@ type RevisionMetadata struct {
 	ManifestSignature string        // Signature of the revision manifest, signed with user's address key of the share.
 	SignatureEmail    string        // Email of the user that signed the revision.
 	State             RevisionState // State of revision
+	XAttr             string        // modification time and size from the file system
 	Thumbnail         Bool          // Whether the revision has a thumbnail
 	ThumbnailHash     string        // Hash of the thumbnail
+}
+
+func (revisionMetadata *RevisionMetadata) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+	if revisionMetadata.XAttr == "" {
+		return nil, nil
+	}
+
+	// decrypt the modification time and size
+	XAttrMsg, err := crypto.NewPGPMessageFromArmored(revisionMetadata.XAttr)
+	if err != nil {
+		return nil, err
+	}
+
+	decXAttr, err := nodeKR.Decrypt(XAttrMsg, addrKR, crypto.GetUnixTime())
+	if err != nil {
+		return nil, err
+	}
+
+	var data RevisionXAttr
+	err = json.Unmarshal(decXAttr.Data, &data)
+	if err != nil {
+		// TODO: if Unmarshal fails, maybe it's because the file system is missing the field?
+		return nil, err
+	}
+
+	return &data.Common, nil
 }
 
 // Revisions are only for files, they represent “versions” of files.
@@ -172,6 +202,32 @@ type Revision struct {
 	RevisionMetadata
 
 	Blocks []Block
+}
+
+func (revision *Revision) GetDecXAttrString(addrKR, nodeKR *crypto.KeyRing) (*RevisionXAttrCommon, error) {
+	if revision.XAttr == "" {
+		return nil, nil
+	}
+
+	// decrypt the modification time and size
+	XAttrMsg, err := crypto.NewPGPMessageFromArmored(revision.XAttr)
+	if err != nil {
+		return nil, err
+	}
+
+	decXAttr, err := nodeKR.Decrypt(XAttrMsg, addrKR, crypto.GetUnixTime())
+	if err != nil {
+		return nil, err
+	}
+
+	var data RevisionXAttr
+	err = json.Unmarshal(decXAttr.Data, &data)
+	if err != nil {
+		// TODO: if Unmarshal fails, maybe it's because the file system is missing the field?
+		return nil, err
+	}
+
+	return &data.Common, nil
 }
 
 type RevisionState int


### PR DESCRIPTION
feat(xattr): generic unknown-section passthrough on RevisionXAttr
    
Add a forward-compatible passthrough for arbitrary top-level XAttr
sections so unmodeled data (Media, Camera, Location, POSIX, ...)
survives a decode/encode cycle byte-equivalently.
    
- Add `Extra map[string]json.RawMessage` (json:"-") to RevisionXAttr
  with custom MarshalJSON/UnmarshalJSON via the alias-type technique:
  the typed `Common` section is handled through revisionXAttrAlias while
  every other top-level section is captured into / spliced from `Extra`
  verbatim. Top-level keys are emitted in sorted order for deterministic
  output. Typed `Common` wins over any stray `Extra["Common"]`; a blob
  with no `Common` yields a zero Common plus all sections in `Extra`; an
  empty object leaves `Extra` nil.
- Add `Mode` field t `POSIX` namesapce for storing Unix permission bits.
  Zero means unset; existing revisions without Mode decode cleanly.
- Switch helper signatures to carry the full *RevisionXAttr:
  SetEncXAttrString marshals Common + Extra together, and both
  GetDecXAttrString methods (on RevisionMetadata and Revision) return
  *RevisionXAttr (nil when no XAttr is present).
- Add rapid property tests plus lossless unit tests covering round-trip
  byte-equivalence, marshal determinism, and the stray-Common, no-Common,
  and empty-object cases.

Depends-on: #237 (feat/file_extended_attributes)