### PR TITLE
fix: retry refresh only on transient failures, not on de-auth

### DIFF
--- a/response.go
+++ b/response.go
@@ -179,7 +179,12 @@ func retryRefreshFailed(res *resty.Response, err error) bool {
 		return false
 	}
 
-	return res.RawResponse == nil || res.StatusCode() == http.StatusBadRequest || res.StatusCode() == http.StatusUnprocessableEntity
+	// Retry only transient refresh failures: no response reached us
+	// (network error / timeout) or a 5xx server error. A 400 or 422 on
+	// /auth/v4/refresh is the permanent de-auth signal (see authRefresh,
+	// which treats those exact codes as de-auth); retrying them cannot
+	// succeed and only delays the de-auth while hammering the endpoint.
+	return res.RawResponse == nil || res.StatusCode() >= http.StatusInternalServerError
 }
 
 func catchTooManyRequests(res *resty.Response, _ error) bool {

--- a/response_retry_test.go
+++ b/response_retry_test.go
@@ -20,9 +20,10 @@ func TestRetryRefreshFailed(t *testing.T) {
 		want bool
 	}{
 		{name: "no error", res: refreshRes(refreshURL, http.StatusInternalServerError), err: nil, want: false},
-		{name: "refresh 500", res: refreshRes(refreshURL, http.StatusInternalServerError), err: errors.New("boom"), want: false},
-		{name: "refresh 400", res: refreshRes(refreshURL, http.StatusBadRequest), err: errors.New("deauth"), want: true},
-		{name: "refresh 422", res: refreshRes(refreshURL, http.StatusUnprocessableEntity), err: errors.New("error"), want: true},
+		{name: "refresh 500", res: refreshRes(refreshURL, http.StatusInternalServerError), err: errors.New("boom"), want: true},
+		{name: "refresh 400", res: refreshRes(refreshURL, http.StatusBadRequest), err: errors.New("deauth"), want: false},
+		{name: "refresh 422", res: refreshRes(refreshURL, http.StatusUnprocessableEntity), err: errors.New("error"), want: false},
+		{name: "refresh no response", res: &resty.Response{Request: &resty.Request{URL: refreshURL}}, err: errors.New("dial"), want: true},
 		{name: "refresh 200 hook error", res: refreshRes(refreshURL, http.StatusOK), err: errors.New("update time"), want: false},
 		{name: "other 500", res: refreshRes(otherURL, http.StatusInternalServerError), err: errors.New("boom"), want: false},
 	}


### PR DESCRIPTION
retryRefreshFailed (added in 0f1b604, "feat(BRIDGE-586): add retry-condition for refresh failed") retries a failed /auth/v4/refresh when the response is 400 or 422, and does not retry 5xx. This appears inverted:

  - 400 and 422 on /auth/v4/refresh are the permanent de-auth signal. authRefresh in client.go treats those exact status codes as de-auth (running the de-auth handlers). Retrying them cannot succeed with the same dead refresh token; with the default retryCount of 3 it issues four refresh attempts, hammering the auth endpoint and delaying the de-auth signal to callers.
  - 5xx is a transient server error that is the normal candidate for a retry, yet it is currently excluded.

Narrow the condition to retry only genuinely transient failures: no response reached the client (network error / timeout) or a 5xx server error. 400/422 now fall through immediately so the de-auth path fires on the first response. The accompanying test's expectations are corrected to match (400/422 -> no retry, 500 -> retry).

Note: BRIDGE-586 broke unit tests in https://github.com/major0/proton-utils.git due to the seemingly inverted retry logic.

Refs:
- ProtonMail/go-proton-api@0f1b604
- https://blog.postman.com/http-422-error/