### PR TITLE
fix(server): resolve data race in countBytesRead test helper

### DIFF
--- a/server/countbytesread_prop_test.go
+++ b/server/countbytesread_prop_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/quick"
+)
+
+// This file holds preservation tests for the countBytesRead byte-count
+// accumulation logic. They encode the baseline behavior that must be preserved
+// by the atomic-load fix: once the OnRead callbacks have quiesced, the value
+// read from the counter equals the plain arithmetic sum of the delivered read
+// lengths, independent of how the callbacks were scheduled.
+//
+// The tests are deterministic and transport-free. They exercise the same
+// accumulation the helper uses (atomic.AddUint64 in the callback, then a load
+// of the counter) directly, so they pass on the unfixed codebase and continue
+// to pass after the fix. See design.md "Preservation Checking".
+
+// accumulateReads mirrors countBytesRead's accumulation: each read length is
+// added to the counter with atomic.AddUint64 (as the OnRead callback does), and
+// the total is returned with atomic.LoadUint64 (the fixed helper's synchronized
+// load). Because the writes have all completed before the load, the result must
+// equal the plain arithmetic sum of the lengths.
+func accumulateReads(lengths []uint32) uint64 {
+	var read uint64
+
+	for _, n := range lengths {
+		atomic.AddUint64(&read, uint64(n))
+	}
+
+	return atomic.LoadUint64(&read)
+}
+
+// plainSum returns the non-atomic arithmetic sum of the lengths, modeling the
+// original helper's plain `return read` once callbacks have quiesced.
+func plainSum(lengths []uint32) uint64 {
+	var sum uint64
+
+	for _, n := range lengths {
+		sum += uint64(n)
+	}
+
+	return sum
+}
+
+// TestCountBytesReadAccumulationExamples covers the concrete unit cases from the
+// design's Unit Tests: the accumulated total equals the sum for a controlled
+// sequence of reads, and the total is 0 when no reads occur.
+func TestCountBytesReadAccumulationExamples(t *testing.T) {
+	tests := []struct {
+		name    string
+		lengths []uint32
+		want    uint64
+	}{
+		{name: "no reads", lengths: nil, want: 0},
+		{name: "single read", lengths: []uint32{7}, want: 7},
+		{name: "controlled sequence", lengths: []uint32{1, 2, 3, 4, 5}, want: 15},
+		{name: "zero-length reads", lengths: []uint32{0, 0, 0}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accumulateReads(tt.lengths); got != tt.want {
+				t.Fatalf("accumulateReads(%v) = %d, want %d", tt.lengths, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPropertyCountBytesReadAccumulation checks that for random sequences of
+// read lengths applied via the callback accumulation logic, the atomic load of
+// the counter equals the plain sum of the lengths (fixed == original once the
+// callbacks have quiesced).
+//
+// **Validates: Requirements 3.1**
+func TestPropertyCountBytesReadAccumulation(t *testing.T) {
+	property := func(lengths []uint32) bool {
+		return accumulateReads(lengths) == plainSum(lengths)
+	}
+
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPropertyCountBytesReadInterleaving checks that the final accumulated total
+// is invariant to callback interleaving: firing the OnRead-style atomic writes
+// concurrently across many goroutines and loading the counter after they have
+// all quiesced still yields the plain sum of the lengths.
+//
+// **Validates: Requirements 3.1**
+func TestPropertyCountBytesReadInterleaving(t *testing.T) {
+	property := func(lengths []uint32) bool {
+		var read uint64
+
+		var wg sync.WaitGroup
+		wg.Add(len(lengths))
+		for _, n := range lengths {
+			go func(n uint32) {
+				defer wg.Done()
+				atomic.AddUint64(&read, uint64(n))
+			}(n)
+		}
+		wg.Wait()
+
+		// wg.Wait() establishes a happens-before edge over every write, so the
+		// load observes the fully accumulated total regardless of scheduling.
+		return atomic.LoadUint64(&read) == plainSum(lengths)
+	}
+
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2633,7 +2633,7 @@ func countBytesRead(ctl *proton.NetCtl, fn func()) uint64 {
 
 	fn()
 
-	return read
+	return atomic.LoadUint64(&read)
 }
 
 type testCookieJar struct {


### PR DESCRIPTION
## Summary

Fixes an intermittent data race in the `countBytesRead` test helper in `server/server_test.go`.

The helper read its byte counter with a plain non-atomic load (`return read`) while `OnRead` callbacks running on lingering `http.Transport` readLoop goroutines wrote to it via `atomic.AddUint64`. The race detector flags this intermittently (~10% of runs) during `TestServer_Messages_Fetch`:

- **Reader** (test goroutine): the non-atomic `return read` in `countBytesRead`.
- **Writer** (`http.Transport` readLoop goroutine): `atomic.AddUint64` via `NetCtl.read` in the `OnRead` callback.

There is no happens-before edge ordering the callback write before the return load, so the mixed atomic-write / non-atomic-read on the same counter is a genuine data race.

## Fix

Pair the atomic write with an atomic read:

```go
-	return read
+	return atomic.LoadUint64(&read)
```

Every access to the counter is now synchronized, eliminating the race while preserving the returned byte-count semantics exactly. `sync/atomic` is already imported. No quiescence barrier or callback deregistration was added, as that would be unnecessary complexity.

## Tests

Adds preservation property/unit tests for the byte-count accumulation invariant in `server/countbytesread_prop_test.go`:

- `TestCountBytesReadAccumulationExamples`
- `TestPropertyCountBytesReadAccumulation`
- `TestPropertyCountBytesReadInterleaving`

## Verification

- `go test -race ./server/...` — passes, no `DATA RACE` reported.
- `go test ./server/...` — passes, unchanged.
- `go test -race -run TestServer_Messages_Fetch -count=20` — race-free across all 20 repetitions (previously reproduced the race reliably).
